### PR TITLE
Add publisher contracts and headless scrape runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,22 @@ publisher. The supported surface is the scraper and publisher path only.
 ## Architecture
 
 See [docs/scraping_surface.md](docs/scraping_surface.md) for the current scrape-only boundary.
+See [docs/published_data.md](docs/published_data.md) for the publisher artifact
+contract and repository data layout.
+
+## Publisher CLI
+
+The headless publisher entrypoint is `python -m publisher.runner`.
+
+```bash
+python -m publisher.runner --output-root data --timestamp 2026-03-23T12:00:00Z scrape-archetypes --format Modern
+python -m publisher.runner --output-root data --timestamp 2026-03-23T12:00:00Z scrape-decks --format Modern --archetype "Temur Rhinos" --days 7
+python -m publisher.runner --output-root data --timestamp 2026-03-23T12:00:00Z scrape-deck-texts --format Modern --archetype "Temur Rhinos" --days 7
+python -m publisher.runner --output-root data --timestamp 2026-03-23T12:00:00Z scrape-metagame --format Modern --day 2026-03-23
+```
+
+Outputs are written into repository-managed staging paths under `data/latest/`,
+`data/hourly/`, and `data/daily/`.
 
 ## Development
 

--- a/docs/published_data.md
+++ b/docs/published_data.md
@@ -1,0 +1,115 @@
+# Published Data Contracts
+
+Issue `#1` Step 1 freezes the on-disk publisher contract before workflow logic
+changes. All published artifacts are versioned JSON documents under `data/`.
+
+## Repository Layout
+
+- `data/latest/`: stable consumer-facing pointers for the freshest successful
+  scrape output.
+- `data/latest/latest.json`: top-level manifest listing the latest artifact for
+  each format and archetype.
+- `data/hourly/<timestamp>/`: hourly snapshots for archetype lists, archetype
+  deck metadata, and deck text blobs.
+- `data/daily/<date>/`: daily metagame snapshots.
+- `data/archive/`: reserved for future compressed exports or hand-curated
+  archive manifests.
+
+Checked-tree retention is one week. Consumers should rely on `data/latest/`
+instead of scanning historical directories.
+
+## Artifact Kinds
+
+Every artifact includes:
+
+- `schema_version`: currently `"1"`.
+- `kind`: one of `latest_manifest`, `archetype_list`, `archetype_decks`,
+  `metagame_daily`, or `deck_text_blob`.
+- `generated_at`: UTC ISO-8601 timestamp with `Z` suffix.
+- `format`: normalized format slug such as `modern` or `pioneer` for all
+  non-manifest artifacts.
+
+### `latest_manifest`
+
+Stored at `data/latest/latest.json`.
+
+- `retention_days`: checked-tree retention target, currently `7`.
+- `latest.archetype_lists[]`: latest archetype list snapshot per format.
+- `latest.archetype_decks[]`: latest deck metadata snapshot per
+  format/archetype.
+- `latest.metagame_daily[]`: latest metagame daily snapshot per format.
+- `latest.deck_text_blobs[]`: latest deck text blob per format/archetype.
+
+Each entry contains `format`, `path`, `updated_at`, and `archetype` when the
+artifact is archetype-scoped.
+
+### `archetype_list`
+
+Written to:
+
+- `data/latest/archetypes/<format>.json`
+- `data/hourly/<timestamp>/archetypes/<format>.json`
+
+Fields:
+
+- `source`: `mtggoldfish`.
+- `archetypes[]`: objects with `name` and `href`.
+
+Freshness target: hourly.
+
+### `archetype_decks`
+
+Written to:
+
+- `data/latest/decks/<format>/<archetype>.json`
+- `data/hourly/<timestamp>/decks/<format>/<archetype>.json`
+
+Fields:
+
+- `source`: `mtggoldfish`, `mtgo`, or `both`.
+- `archetype`: object with `name` and `href`.
+- `decks[]`: deck metadata rows from the scrape surface.
+
+Freshness target: hourly.
+
+### `metagame_daily`
+
+Written to:
+
+- `data/latest/metagame/<format>.json`
+- `data/daily/<date>/metagame/<format>.json`
+
+Fields:
+
+- `source`: `mtggoldfish`.
+- `generated_for_day`: daily snapshot date.
+- `stats[]`: objects with `archetype`, `deck_count`, and `daily_counts`.
+
+Freshness target: daily.
+
+### `deck_text_blob`
+
+Written to:
+
+- `data/latest/deck-texts/<format>/<archetype>.json`
+- `data/hourly/<timestamp>/deck-texts/<format>/<archetype>.json`
+
+Fields:
+
+- `source`: `mtggoldfish`, `mtgo`, or `both`.
+- `archetype`: object with `name` and `href`.
+- `deck_texts[]`: objects with `deck_id`, `deck_name`, `deck_date`, `source`,
+  and `deck_text`.
+
+Freshness target: hourly.
+
+## Consumer Expectations
+
+- Consumers should treat missing historical snapshots as normal after the
+  seven-day retention window.
+- Consumers should use `data/latest/latest.json` to discover current paths.
+- Hourly consumers should expect archetype lists, deck metadata, and deck text
+  blobs to advance together by timestamp, but only daily consumers should rely
+  on `data/daily/`.
+- `deck_text_blob` contents may be empty when a run intentionally scopes to no
+  matching recent decks; the blob is still valid and deterministic.

--- a/publisher/__init__.py
+++ b/publisher/__init__.py
@@ -1,0 +1,21 @@
+"""Publisher contracts and headless scrape runner entrypoints."""
+
+from publisher.contracts import (
+    SCHEMA_VERSION,
+    validate_archetype_deck_snapshot,
+    validate_archetype_list_snapshot,
+    validate_deck_text_blob,
+    validate_latest_manifest,
+    validate_metagame_snapshot,
+)
+from publisher.runner import main
+
+__all__ = [
+    "SCHEMA_VERSION",
+    "main",
+    "validate_archetype_deck_snapshot",
+    "validate_archetype_list_snapshot",
+    "validate_deck_text_blob",
+    "validate_latest_manifest",
+    "validate_metagame_snapshot",
+]

--- a/publisher/contracts.py
+++ b/publisher/contracts.py
@@ -1,0 +1,220 @@
+"""Published artifact builders and validators for scrape snapshots."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from copy import deepcopy
+from typing import Any
+
+SCHEMA_VERSION = "1"
+LATEST_MANIFEST_KIND = "latest_manifest"
+ARCHETYPE_LIST_KIND = "archetype_list"
+ARCHETYPE_DECKS_KIND = "archetype_decks"
+METAGAME_KIND = "metagame_daily"
+DECK_TEXTS_KIND = "deck_text_blob"
+
+
+def _require_mapping(payload: Any, kind: str) -> Mapping[str, Any]:
+    if not isinstance(payload, Mapping):
+        raise ValueError(f"{kind} payload must be a mapping")
+    return payload
+
+
+def _require_string(payload: Mapping[str, Any], key: str, kind: str) -> str:
+    value = payload.get(key)
+    if not isinstance(value, str) or not value:
+        raise ValueError(f"{kind}.{key} must be a non-empty string")
+    return value
+
+
+def _require_sequence(payload: Mapping[str, Any], key: str, kind: str) -> Sequence[Any]:
+    value = payload.get(key)
+    if not isinstance(value, Sequence) or isinstance(value, str | bytes | bytearray):
+        raise ValueError(f"{kind}.{key} must be a sequence")
+    return value
+
+
+def _validate_common_snapshot(payload: Any, *, kind: str) -> Mapping[str, Any]:
+    snapshot = _require_mapping(payload, kind)
+    if snapshot.get("schema_version") != SCHEMA_VERSION:
+        raise ValueError(f"{kind}.schema_version must be {SCHEMA_VERSION}")
+    if snapshot.get("kind") != kind:
+        raise ValueError(f"{kind}.kind must be {kind}")
+    _require_string(snapshot, "generated_at", kind)
+    _require_string(snapshot, "format", kind)
+    return snapshot
+
+
+def build_latest_manifest(*, generated_at: str, retention_days: int) -> dict[str, Any]:
+    if retention_days < 1:
+        raise ValueError("retention_days must be at least 1")
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "kind": LATEST_MANIFEST_KIND,
+        "generated_at": generated_at,
+        "retention_days": retention_days,
+        "latest": {
+            "archetype_lists": [],
+            "archetype_decks": [],
+            "metagame_daily": [],
+            "deck_text_blobs": [],
+        },
+    }
+
+
+def build_archetype_list_snapshot(
+    *, generated_at: str, format_name: str, source: str, archetypes: Sequence[Mapping[str, Any]]
+) -> dict[str, Any]:
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "kind": ARCHETYPE_LIST_KIND,
+        "generated_at": generated_at,
+        "format": format_name,
+        "source": source,
+        "archetypes": [dict(item) for item in archetypes],
+    }
+
+
+def build_archetype_deck_snapshot(
+    *,
+    generated_at: str,
+    format_name: str,
+    archetype: Mapping[str, Any],
+    source: str,
+    decks: Sequence[Mapping[str, Any]],
+) -> dict[str, Any]:
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "kind": ARCHETYPE_DECKS_KIND,
+        "generated_at": generated_at,
+        "format": format_name,
+        "source": source,
+        "archetype": dict(archetype),
+        "decks": [dict(item) for item in decks],
+    }
+
+
+def build_metagame_snapshot(
+    *,
+    generated_at: str,
+    format_name: str,
+    source: str,
+    generated_for_day: str,
+    stats: Sequence[Mapping[str, Any]],
+) -> dict[str, Any]:
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "kind": METAGAME_KIND,
+        "generated_at": generated_at,
+        "format": format_name,
+        "source": source,
+        "generated_for_day": generated_for_day,
+        "stats": [dict(item) for item in stats],
+    }
+
+
+def build_deck_text_blob(
+    *,
+    generated_at: str,
+    format_name: str,
+    archetype: Mapping[str, Any],
+    source: str,
+    deck_texts: Sequence[Mapping[str, Any]],
+) -> dict[str, Any]:
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "kind": DECK_TEXTS_KIND,
+        "generated_at": generated_at,
+        "format": format_name,
+        "source": source,
+        "archetype": dict(archetype),
+        "deck_texts": [dict(item) for item in deck_texts],
+    }
+
+
+def validate_latest_manifest(payload: Any) -> dict[str, Any]:
+    manifest = deepcopy(_require_mapping(payload, LATEST_MANIFEST_KIND))
+    if manifest.get("schema_version") != SCHEMA_VERSION:
+        raise ValueError(f"{LATEST_MANIFEST_KIND}.schema_version must be {SCHEMA_VERSION}")
+    if manifest.get("kind") != LATEST_MANIFEST_KIND:
+        raise ValueError(f"{LATEST_MANIFEST_KIND}.kind must be {LATEST_MANIFEST_KIND}")
+    _require_string(manifest, "generated_at", LATEST_MANIFEST_KIND)
+    retention_days = manifest.get("retention_days")
+    if not isinstance(retention_days, int) or retention_days < 1:
+        raise ValueError("latest_manifest.retention_days must be a positive integer")
+    latest = _require_mapping(manifest.get("latest"), "latest_manifest.latest")
+    required_groups = {
+        "archetype_lists",
+        "archetype_decks",
+        "metagame_daily",
+        "deck_text_blobs",
+    }
+    for group in required_groups:
+        entries = _require_sequence(latest, group, "latest_manifest.latest")
+        for entry in entries:
+            entry_mapping = _require_mapping(entry, f"latest_manifest.latest.{group}[]")
+            _require_string(entry_mapping, "format", f"latest_manifest.latest.{group}[]")
+            _require_string(entry_mapping, "path", f"latest_manifest.latest.{group}[]")
+            _require_string(entry_mapping, "updated_at", f"latest_manifest.latest.{group}[]")
+    return manifest
+
+
+def validate_archetype_list_snapshot(payload: Any) -> dict[str, Any]:
+    snapshot = deepcopy(_validate_common_snapshot(payload, kind=ARCHETYPE_LIST_KIND))
+    _require_string(snapshot, "source", ARCHETYPE_LIST_KIND)
+    archetypes = _require_sequence(snapshot, "archetypes", ARCHETYPE_LIST_KIND)
+    for entry in archetypes:
+        archetype = _require_mapping(entry, f"{ARCHETYPE_LIST_KIND}.archetypes[]")
+        _require_string(archetype, "name", f"{ARCHETYPE_LIST_KIND}.archetypes[]")
+        _require_string(archetype, "href", f"{ARCHETYPE_LIST_KIND}.archetypes[]")
+    return dict(snapshot)
+
+
+def validate_archetype_deck_snapshot(payload: Any) -> dict[str, Any]:
+    snapshot = deepcopy(_validate_common_snapshot(payload, kind=ARCHETYPE_DECKS_KIND))
+    _require_string(snapshot, "source", ARCHETYPE_DECKS_KIND)
+    archetype = _require_mapping(snapshot.get("archetype"), f"{ARCHETYPE_DECKS_KIND}.archetype")
+    _require_string(archetype, "name", f"{ARCHETYPE_DECKS_KIND}.archetype")
+    _require_string(archetype, "href", f"{ARCHETYPE_DECKS_KIND}.archetype")
+    decks = _require_sequence(snapshot, "decks", ARCHETYPE_DECKS_KIND)
+    for entry in decks:
+        deck = _require_mapping(entry, f"{ARCHETYPE_DECKS_KIND}.decks[]")
+        _require_string(deck, "number", f"{ARCHETYPE_DECKS_KIND}.decks[]")
+        _require_string(deck, "source", f"{ARCHETYPE_DECKS_KIND}.decks[]")
+    return dict(snapshot)
+
+
+def validate_metagame_snapshot(payload: Any) -> dict[str, Any]:
+    snapshot = deepcopy(_validate_common_snapshot(payload, kind=METAGAME_KIND))
+    _require_string(snapshot, "source", METAGAME_KIND)
+    _require_string(snapshot, "generated_for_day", METAGAME_KIND)
+    stats = _require_sequence(snapshot, "stats", METAGAME_KIND)
+    for entry in stats:
+        item = _require_mapping(entry, f"{METAGAME_KIND}.stats[]")
+        _require_string(item, "archetype", f"{METAGAME_KIND}.stats[]")
+        deck_count = item.get("deck_count")
+        if not isinstance(deck_count, int) or deck_count < 0:
+            raise ValueError(f"{METAGAME_KIND}.stats[].deck_count must be a non-negative integer")
+        daily_counts = _require_mapping(item.get("daily_counts"), f"{METAGAME_KIND}.stats[]")
+        for key, value in daily_counts.items():
+            if not isinstance(key, str) or not key:
+                raise ValueError(f"{METAGAME_KIND}.stats[].daily_counts keys must be strings")
+            if not isinstance(value, int) or value < 0:
+                raise ValueError(
+                    f"{METAGAME_KIND}.stats[].daily_counts values must be non-negative integers"
+                )
+    return dict(snapshot)
+
+
+def validate_deck_text_blob(payload: Any) -> dict[str, Any]:
+    snapshot = deepcopy(_validate_common_snapshot(payload, kind=DECK_TEXTS_KIND))
+    _require_string(snapshot, "source", DECK_TEXTS_KIND)
+    archetype = _require_mapping(snapshot.get("archetype"), f"{DECK_TEXTS_KIND}.archetype")
+    _require_string(archetype, "name", f"{DECK_TEXTS_KIND}.archetype")
+    _require_string(archetype, "href", f"{DECK_TEXTS_KIND}.archetype")
+    deck_texts = _require_sequence(snapshot, "deck_texts", DECK_TEXTS_KIND)
+    for entry in deck_texts:
+        item = _require_mapping(entry, f"{DECK_TEXTS_KIND}.deck_texts[]")
+        _require_string(item, "deck_id", f"{DECK_TEXTS_KIND}.deck_texts[]")
+        _require_string(item, "deck_text", f"{DECK_TEXTS_KIND}.deck_texts[]")
+    return dict(snapshot)

--- a/publisher/layout.py
+++ b/publisher/layout.py
@@ -1,0 +1,80 @@
+"""Repository data layout helpers for published scrape artifacts."""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+from publisher.contracts import build_latest_manifest, validate_latest_manifest
+from utils.atomic_io import atomic_write_json
+
+DEFAULT_OUTPUT_ROOT = Path("data")
+DEFAULT_RETENTION_DAYS = 7
+
+
+def normalize_name(value: str) -> str:
+    return re.sub(r"[^a-z0-9]+", "-", value.strip().lower()).strip("-")
+
+
+def timestamp_token(timestamp: str) -> str:
+    return timestamp.replace(":", "-")
+
+
+def hourly_snapshot_dir(output_root: Path, generated_at: str) -> Path:
+    return output_root / "hourly" / timestamp_token(generated_at)
+
+
+def daily_snapshot_dir(output_root: Path, generated_for_day: str) -> Path:
+    return output_root / "daily" / generated_for_day
+
+
+def load_latest_manifest(
+    output_root: Path, *, generated_at: str, retention_days: int
+) -> dict[str, Any]:
+    manifest_path = output_root / "latest" / "latest.json"
+    if not manifest_path.exists():
+        return build_latest_manifest(generated_at=generated_at, retention_days=retention_days)
+    with manifest_path.open("r", encoding="utf-8") as fh:
+        manifest = json.load(fh)
+    validated = validate_latest_manifest(manifest)
+    validated["generated_at"] = generated_at
+    validated["retention_days"] = retention_days
+    return validated
+
+
+def write_json(path: Path, payload: dict[str, Any]) -> None:
+    atomic_write_json(path, payload, indent=2)
+
+
+def update_latest_manifest(
+    output_root: Path,
+    *,
+    generated_at: str,
+    retention_days: int,
+    category: str,
+    discriminator: dict[str, str],
+    relative_path: str,
+) -> Path:
+    manifest = load_latest_manifest(
+        output_root,
+        generated_at=generated_at,
+        retention_days=retention_days,
+    )
+    entries = manifest["latest"][category]
+    filtered_entries = [
+        entry for entry in entries if any(entry.get(k) != v for k, v in discriminator.items())
+    ]
+    filtered_entries.append({**discriminator, "path": relative_path, "updated_at": generated_at})
+    filtered_entries.sort(
+        key=lambda entry: (
+            entry.get("format", ""),
+            entry.get("archetype", ""),
+            entry.get("path", ""),
+        )
+    )
+    manifest["latest"][category] = filtered_entries
+    manifest_path = output_root / "latest" / "latest.json"
+    write_json(manifest_path, manifest)
+    return manifest_path

--- a/publisher/runner.py
+++ b/publisher/runner.py
@@ -1,0 +1,382 @@
+"""CLI entrypoint for headless scrape publishing."""
+
+from __future__ import annotations
+
+import argparse
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+from loguru import logger
+
+from navigators.mtggoldfish import get_archetype_stats
+from publisher.contracts import (
+    build_archetype_deck_snapshot,
+    build_archetype_list_snapshot,
+    build_deck_text_blob,
+    build_metagame_snapshot,
+    validate_archetype_deck_snapshot,
+    validate_archetype_list_snapshot,
+    validate_deck_text_blob,
+    validate_metagame_snapshot,
+)
+from publisher.layout import (
+    DEFAULT_OUTPUT_ROOT,
+    DEFAULT_RETENTION_DAYS,
+    daily_snapshot_dir,
+    hourly_snapshot_dir,
+    normalize_name,
+    update_latest_manifest,
+    write_json,
+)
+from scraping import ScrapingMetagameRepository, fetch_archetypes
+
+try:
+    from datetime import UTC
+except ImportError:  # pragma: no cover - Python 3.10 fallback
+    UTC = timezone.utc  # noqa: UP017
+
+
+def _utc_now() -> str:
+    return datetime.now(UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _normalize_format_name(format_name: str) -> str:
+    return normalize_name(format_name)
+
+
+def _parse_timestamp(value: str | None) -> str:
+    if value:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+        return parsed.astimezone(UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+    return _utc_now()
+
+
+def _parse_day(timestamp: str, override: str | None = None) -> str:
+    if override:
+        return override
+    return timestamp.split("T", 1)[0]
+
+
+def _parse_deck_date(date_str: str) -> datetime | None:
+    for fmt in ("%Y-%m-%d", "%m/%d/%Y"):
+        try:
+            return datetime.strptime(date_str, fmt)
+        except ValueError:
+            continue
+    return None
+
+
+def _filter_recent_decks(decks: list[dict[str, Any]], days: int | None) -> list[dict[str, Any]]:
+    if days is None:
+        return decks
+    cutoff = datetime.now() - timedelta(days=days)
+    filtered: list[dict[str, Any]] = []
+    for deck in decks:
+        parsed = _parse_deck_date(deck.get("date", ""))
+        if parsed is None or parsed >= cutoff:
+            filtered.append(deck)
+    return filtered
+
+
+def _selected_archetypes(
+    format_name: str, archetype_filters: list[str] | None
+) -> list[dict[str, Any]]:
+    archetypes = sorted(
+        fetch_archetypes(format_name, allow_stale=True),
+        key=lambda item: (item.get("name", "").lower(), item.get("href", "").lower()),
+    )
+    if not archetype_filters:
+        return archetypes
+    wanted = {normalize_name(value) for value in archetype_filters}
+    return [item for item in archetypes if normalize_name(item.get("name", "")) in wanted]
+
+
+def _write_archetype_list_snapshot(
+    *,
+    output_root: Path,
+    generated_at: str,
+    retention_days: int,
+    format_name: str,
+    archetypes: list[dict[str, Any]],
+) -> None:
+    normalized_format = _normalize_format_name(format_name)
+    snapshot = build_archetype_list_snapshot(
+        generated_at=generated_at,
+        format_name=normalized_format,
+        source="mtggoldfish",
+        archetypes=archetypes,
+    )
+    validate_archetype_list_snapshot(snapshot)
+    latest_path = output_root / "latest" / "archetypes" / f"{normalized_format}.json"
+    hourly_path = (
+        hourly_snapshot_dir(output_root, generated_at) / "archetypes" / f"{normalized_format}.json"
+    )
+    write_json(latest_path, snapshot)
+    write_json(hourly_path, snapshot)
+    update_latest_manifest(
+        output_root,
+        generated_at=generated_at,
+        retention_days=retention_days,
+        category="archetype_lists",
+        discriminator={"format": normalized_format},
+        relative_path=str(latest_path.relative_to(output_root)),
+    )
+
+
+def _write_metagame_snapshot(
+    *,
+    output_root: Path,
+    generated_at: str,
+    retention_days: int,
+    format_name: str,
+    generated_for_day: str,
+) -> None:
+    raw_stats = get_archetype_stats(format_name)
+    format_stats = raw_stats.get(format_name.lower(), {})
+    stats_rows = []
+    for archetype, payload in sorted(format_stats.items()):
+        if archetype == "timestamp":
+            continue
+        daily_counts = payload.get("results", {})
+        stats_rows.append(
+            {
+                "archetype": archetype,
+                "deck_count": len(payload.get("decks", [])),
+                "daily_counts": {key: daily_counts[key] for key in sorted(daily_counts)},
+            }
+        )
+    normalized_format = _normalize_format_name(format_name)
+    snapshot = build_metagame_snapshot(
+        generated_at=generated_at,
+        format_name=normalized_format,
+        source="mtggoldfish",
+        generated_for_day=generated_for_day,
+        stats=stats_rows,
+    )
+    validate_metagame_snapshot(snapshot)
+    latest_path = output_root / "latest" / "metagame" / f"{normalized_format}.json"
+    daily_path = (
+        daily_snapshot_dir(output_root, generated_for_day)
+        / "metagame"
+        / f"{normalized_format}.json"
+    )
+    write_json(latest_path, snapshot)
+    write_json(daily_path, snapshot)
+    update_latest_manifest(
+        output_root,
+        generated_at=generated_at,
+        retention_days=retention_days,
+        category="metagame_daily",
+        discriminator={"format": normalized_format},
+        relative_path=str(latest_path.relative_to(output_root)),
+    )
+
+
+def _write_deck_text_blobs(
+    *,
+    output_root: Path,
+    generated_at: str,
+    retention_days: int,
+    format_name: str,
+    archetype_filters: list[str] | None,
+    days: int | None,
+    source_filter: str | None,
+) -> None:
+    repo = ScrapingMetagameRepository()
+    normalized_format = _normalize_format_name(format_name)
+    for archetype in _selected_archetypes(format_name, archetype_filters):
+        decks = repo.get_decks_for_archetype(
+            archetype, force_refresh=True, source_filter=source_filter
+        )
+        recent_decks = _filter_recent_decks(decks, days)
+        deck_texts = []
+        seen_deck_ids: set[str] = set()
+        for deck in recent_decks:
+            deck_id = str(deck.get("number", "")).strip()
+            if not deck_id or deck_id in seen_deck_ids:
+                continue
+            seen_deck_ids.add(deck_id)
+            deck_texts.append(
+                {
+                    "deck_id": deck_id,
+                    "deck_name": deck.get("name", archetype["name"]),
+                    "deck_date": deck.get("date", ""),
+                    "source": deck.get("source", source_filter or "mtggoldfish"),
+                    "deck_text": repo.download_deck_content(deck, source_filter=source_filter),
+                }
+            )
+        deck_texts.sort(key=lambda item: item["deck_id"])
+        snapshot = build_deck_text_blob(
+            generated_at=generated_at,
+            format_name=normalized_format,
+            archetype=archetype,
+            source=source_filter or "both",
+            deck_texts=deck_texts,
+        )
+        validate_deck_text_blob(snapshot)
+        archetype_slug = normalize_name(archetype["name"])
+        latest_path = (
+            output_root / "latest" / "deck-texts" / normalized_format / f"{archetype_slug}.json"
+        )
+        hourly_path = (
+            hourly_snapshot_dir(output_root, generated_at)
+            / "deck-texts"
+            / normalized_format
+            / f"{archetype_slug}.json"
+        )
+        write_json(latest_path, snapshot)
+        write_json(hourly_path, snapshot)
+        update_latest_manifest(
+            output_root,
+            generated_at=generated_at,
+            retention_days=retention_days,
+            category="deck_text_blobs",
+            discriminator={"format": normalized_format, "archetype": archetype_slug},
+            relative_path=str(latest_path.relative_to(output_root)),
+        )
+
+
+def _write_archetype_deck_snapshots(
+    *,
+    output_root: Path,
+    generated_at: str,
+    retention_days: int,
+    format_name: str,
+    archetype_filters: list[str] | None,
+    days: int | None,
+    source_filter: str | None,
+) -> None:
+    repo = ScrapingMetagameRepository()
+    normalized_format = _normalize_format_name(format_name)
+    for archetype in _selected_archetypes(format_name, archetype_filters):
+        decks = repo.get_decks_for_archetype(
+            archetype, force_refresh=True, source_filter=source_filter
+        )
+        recent_decks = sorted(
+            _filter_recent_decks(decks, days),
+            key=lambda item: (
+                item.get("date", ""),
+                item.get("number", ""),
+                item.get("player", ""),
+            ),
+            reverse=True,
+        )
+        snapshot = build_archetype_deck_snapshot(
+            generated_at=generated_at,
+            format_name=normalized_format,
+            archetype=archetype,
+            source=source_filter or "both",
+            decks=recent_decks,
+        )
+        validate_archetype_deck_snapshot(snapshot)
+        archetype_slug = normalize_name(archetype["name"])
+        latest_path = (
+            output_root / "latest" / "decks" / normalized_format / f"{archetype_slug}.json"
+        )
+        hourly_path = (
+            hourly_snapshot_dir(output_root, generated_at)
+            / "decks"
+            / normalized_format
+            / f"{archetype_slug}.json"
+        )
+        write_json(latest_path, snapshot)
+        write_json(hourly_path, snapshot)
+        update_latest_manifest(
+            output_root,
+            generated_at=generated_at,
+            retention_days=retention_days,
+            category="archetype_decks",
+            discriminator={"format": normalized_format, "archetype": archetype_slug},
+            relative_path=str(latest_path.relative_to(output_root)),
+        )
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Headless scrape publisher")
+    parser.add_argument("--output-root", default=str(DEFAULT_OUTPUT_ROOT))
+    parser.add_argument("--timestamp", help="UTC timestamp for deterministic output naming")
+    parser.add_argument("--retention-days", type=int, default=DEFAULT_RETENTION_DAYS)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    archetypes = subparsers.add_parser("scrape-archetypes")
+    archetypes.add_argument("--format", dest="formats", action="append", required=True)
+
+    metagame = subparsers.add_parser("scrape-metagame")
+    metagame.add_argument("--format", dest="formats", action="append", required=True)
+    metagame.add_argument("--day", dest="generated_for_day")
+
+    deck_texts = subparsers.add_parser("scrape-deck-texts")
+    deck_texts.add_argument("--format", dest="formats", action="append", required=True)
+    deck_texts.add_argument("--archetype", dest="archetypes", action="append")
+    deck_texts.add_argument("--days", type=int)
+    deck_texts.add_argument(
+        "--source-filter", choices=["mtggoldfish", "mtgo", "both"], default="both"
+    )
+
+    decks = subparsers.add_parser("scrape-decks")
+    decks.add_argument("--format", dest="formats", action="append", required=True)
+    decks.add_argument("--archetype", dest="archetypes", action="append")
+    decks.add_argument("--days", type=int)
+    decks.add_argument("--source-filter", choices=["mtggoldfish", "mtgo", "both"], default="both")
+
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    generated_at = _parse_timestamp(args.timestamp)
+    output_root = Path(args.output_root)
+
+    if args.command == "scrape-archetypes":
+        for format_name in args.formats:
+            archetypes = _selected_archetypes(format_name, None)
+            _write_archetype_list_snapshot(
+                output_root=output_root,
+                generated_at=generated_at,
+                retention_days=args.retention_days,
+                format_name=format_name,
+                archetypes=archetypes,
+            )
+    elif args.command == "scrape-metagame":
+        generated_for_day = _parse_day(generated_at, args.generated_for_day)
+        for format_name in args.formats:
+            _write_metagame_snapshot(
+                output_root=output_root,
+                generated_at=generated_at,
+                retention_days=args.retention_days,
+                format_name=format_name,
+                generated_for_day=generated_for_day,
+            )
+    elif args.command == "scrape-deck-texts":
+        for format_name in args.formats:
+            _write_deck_text_blobs(
+                output_root=output_root,
+                generated_at=generated_at,
+                retention_days=args.retention_days,
+                format_name=format_name,
+                archetype_filters=args.archetypes,
+                days=args.days,
+                source_filter=None if args.source_filter == "both" else args.source_filter,
+            )
+    elif args.command == "scrape-decks":
+        for format_name in args.formats:
+            _write_archetype_deck_snapshots(
+                output_root=output_root,
+                generated_at=generated_at,
+                retention_days=args.retention_days,
+                format_name=format_name,
+                archetype_filters=args.archetypes,
+                days=args.days,
+                source_filter=None if args.source_filter == "both" else args.source_filter,
+            )
+    else:  # pragma: no cover
+        parser.error(f"Unknown command: {args.command}")
+
+    logger.info("Wrote scrape artifacts to {}", output_root)
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ classifiers = [
 ]
 
 [project.scripts]
+mtgo-scrapes = "publisher.runner:main"
 
 [tool.ruff]
 # Exclude common directories

--- a/setup.py
+++ b/setup.py
@@ -18,9 +18,24 @@ setuptools.setup(
     version="0.2",
     author="yochi",
     author_email="pedrogush@gmail.com",
-    description="MTG Metagame Analysis: Opponent tracking and deck research tools for MTGO",
-    packages=["widgets", "navigators", "utils"],
-    classifiers=["Programming Language :: Python :: 3", "Operating System :: Windows"],
+    description="Headless MTGO and MTGGoldfish scrape publisher",
+    packages=setuptools.find_packages(
+        include=[
+            "navigators",
+            "navigators.*",
+            "publisher",
+            "publisher.*",
+            "repositories",
+            "repositories.*",
+            "scraping",
+            "scraping.*",
+            "services",
+            "services.*",
+            "utils",
+            "utils.*",
+        ]
+    ),
+    classifiers=["Programming Language :: Python :: 3", "Operating System :: OS Independent"],
     python_requires=">=3.11",
     install_requires=load_requirements("requirements.txt"),
 )

--- a/tests/test_publisher_contracts.py
+++ b/tests/test_publisher_contracts.py
@@ -1,0 +1,80 @@
+from publisher.contracts import (
+    build_archetype_deck_snapshot,
+    build_archetype_list_snapshot,
+    build_deck_text_blob,
+    build_latest_manifest,
+    build_metagame_snapshot,
+    validate_archetype_deck_snapshot,
+    validate_archetype_list_snapshot,
+    validate_deck_text_blob,
+    validate_latest_manifest,
+    validate_metagame_snapshot,
+)
+
+TIMESTAMP = "2026-03-23T12:00:00Z"
+
+
+def test_contract_builders_validate_examples() -> None:
+    archetypes = [{"name": "Temur Rhinos", "href": "modern-temur-rhinos"}]
+    archetype_snapshot = build_archetype_list_snapshot(
+        generated_at=TIMESTAMP,
+        format_name="modern",
+        source="mtggoldfish",
+        archetypes=archetypes,
+    )
+    assert validate_archetype_list_snapshot(archetype_snapshot)["archetypes"] == archetypes
+
+    deck_snapshot = build_archetype_deck_snapshot(
+        generated_at=TIMESTAMP,
+        format_name="modern",
+        source="both",
+        archetype=archetypes[0],
+        decks=[{"number": "123", "source": "mtggoldfish", "date": "2026-03-22"}],
+    )
+    assert validate_archetype_deck_snapshot(deck_snapshot)["archetype"]["name"] == "Temur Rhinos"
+
+    metagame_snapshot = build_metagame_snapshot(
+        generated_at=TIMESTAMP,
+        format_name="modern",
+        source="mtggoldfish",
+        generated_for_day="2026-03-23",
+        stats=[{"archetype": "Temur Rhinos", "deck_count": 4, "daily_counts": {"2026-03-22": 4}}],
+    )
+    assert validate_metagame_snapshot(metagame_snapshot)["stats"][0]["deck_count"] == 4
+
+    deck_text_blob = build_deck_text_blob(
+        generated_at=TIMESTAMP,
+        format_name="modern",
+        source="both",
+        archetype=archetypes[0],
+        deck_texts=[{"deck_id": "123", "deck_text": "4 Ragavan, Nimble Pilferer"}],
+    )
+    assert validate_deck_text_blob(deck_text_blob)["deck_texts"][0]["deck_id"] == "123"
+
+
+def test_latest_manifest_validates_with_all_categories() -> None:
+    manifest = build_latest_manifest(generated_at=TIMESTAMP, retention_days=7)
+    manifest["latest"]["archetype_lists"].append(
+        {"format": "modern", "path": "latest/archetypes/modern.json", "updated_at": TIMESTAMP}
+    )
+    manifest["latest"]["archetype_decks"].append(
+        {
+            "format": "modern",
+            "archetype": "temur-rhinos",
+            "path": "latest/decks/modern/temur-rhinos.json",
+            "updated_at": TIMESTAMP,
+        }
+    )
+    manifest["latest"]["metagame_daily"].append(
+        {"format": "modern", "path": "latest/metagame/modern.json", "updated_at": TIMESTAMP}
+    )
+    manifest["latest"]["deck_text_blobs"].append(
+        {
+            "format": "modern",
+            "archetype": "temur-rhinos",
+            "path": "latest/deck-texts/modern/temur-rhinos.json",
+            "updated_at": TIMESTAMP,
+        }
+    )
+
+    assert validate_latest_manifest(manifest)["retention_days"] == 7

--- a/tests/test_publisher_runner.py
+++ b/tests/test_publisher_runner.py
@@ -1,0 +1,119 @@
+import json
+
+from publisher.runner import main
+
+TIMESTAMP = "2026-03-23T12:00:00Z"
+
+
+class _FakeRepo:
+    def get_decks_for_archetype(self, archetype, force_refresh=False, source_filter=None):
+        assert force_refresh is True
+        return [
+            {
+                "name": archetype["name"],
+                "number": "123",
+                "date": "2026-03-22",
+                "player": "Alice",
+                "event": "Modern Challenge",
+                "source": "mtggoldfish",
+            }
+        ]
+
+    def download_deck_content(self, deck, source_filter=None):
+        return f"Deck {deck['number']}"
+
+
+def test_scrape_archetypes_writes_latest_and_hourly(monkeypatch, tmp_path):
+    monkeypatch.setattr(
+        "publisher.runner.fetch_archetypes",
+        lambda *args, **kwargs: [{"name": "Temur Rhinos", "href": "modern-temur-rhinos"}],
+    )
+
+    exit_code = main(
+        [
+            "--output-root",
+            str(tmp_path),
+            "--timestamp",
+            TIMESTAMP,
+            "scrape-archetypes",
+            "--format",
+            "Modern",
+        ]
+    )
+
+    assert exit_code == 0
+    latest_path = tmp_path / "latest" / "archetypes" / "modern.json"
+    manifest_path = tmp_path / "latest" / "latest.json"
+    assert latest_path.exists()
+    assert (tmp_path / "hourly" / "2026-03-23T12-00-00Z" / "archetypes" / "modern.json").exists()
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    assert manifest["latest"]["archetype_lists"][0]["path"] == "latest/archetypes/modern.json"
+
+
+def test_scrape_metagame_writes_daily_snapshot(monkeypatch, tmp_path):
+    monkeypatch.setattr(
+        "publisher.runner.get_archetype_stats",
+        lambda _format: {
+            "modern": {
+                "timestamp": 1.0,
+                "Temur Rhinos": {
+                    "decks": [{"number": "123"}],
+                    "results": {"2026-03-22": 1, "2026-03-23": 0},
+                },
+            }
+        },
+    )
+
+    exit_code = main(
+        [
+            "--output-root",
+            str(tmp_path),
+            "--timestamp",
+            TIMESTAMP,
+            "scrape-metagame",
+            "--format",
+            "Modern",
+            "--day",
+            "2026-03-23",
+        ]
+    )
+
+    assert exit_code == 0
+    latest_path = tmp_path / "latest" / "metagame" / "modern.json"
+    daily_path = tmp_path / "daily" / "2026-03-23" / "metagame" / "modern.json"
+    snapshot = json.loads(latest_path.read_text(encoding="utf-8"))
+    assert latest_path.exists()
+    assert daily_path.exists()
+    assert snapshot["stats"][0]["archetype"] == "Temur Rhinos"
+
+
+def test_scrape_deck_texts_writes_latest_and_manifest(monkeypatch, tmp_path):
+    monkeypatch.setattr(
+        "publisher.runner.fetch_archetypes",
+        lambda *args, **kwargs: [{"name": "Temur Rhinos", "href": "modern-temur-rhinos"}],
+    )
+    monkeypatch.setattr("publisher.runner.ScrapingMetagameRepository", _FakeRepo)
+
+    exit_code = main(
+        [
+            "--output-root",
+            str(tmp_path),
+            "--timestamp",
+            TIMESTAMP,
+            "scrape-deck-texts",
+            "--format",
+            "Modern",
+            "--archetype",
+            "Temur Rhinos",
+            "--days",
+            "7",
+        ]
+    )
+
+    assert exit_code == 0
+    latest_path = tmp_path / "latest" / "deck-texts" / "modern" / "temur-rhinos.json"
+    manifest_path = tmp_path / "latest" / "latest.json"
+    blob = json.loads(latest_path.read_text(encoding="utf-8"))
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    assert blob["deck_texts"][0]["deck_text"] == "Deck 123"
+    assert manifest["latest"]["deck_text_blobs"][0]["path"].endswith("temur-rhinos.json")


### PR DESCRIPTION
## Summary
- define versioned published artifact contracts and repository data layout
- add a headless publisher CLI for archetypes, metagame, deck metadata, and deck texts
- document the new layout and add focused tests for contracts and runner behavior

## Testing
- python3 -m pytest tests/test_publisher_contracts.py tests/test_publisher_runner.py tests/test_scraping_surface.py
- python3 -m ruff check .
- python3 -m black --check .