### PR TITLE
Add scheduled publish workflows and one-week retention

### DIFF
--- a/.github/workflows/publish-daily.yml
+++ b/.github/workflows/publish-daily.yml
@@ -1,0 +1,72 @@
+name: Publish Daily Metagame
+
+on:
+  workflow_dispatch:
+  schedule:
+    # 23:45 America/Sao_Paulo
+    - cron: "45 2 * * *"
+
+permissions:
+  contents: write
+
+concurrency:
+  group: publish-data-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  publish-daily:
+    runs-on: ubuntu-latest
+    env:
+      PUBLISH_FORMATS: "Modern Standard Pioneer Legacy Vintage Pauper"
+      PUBLISH_OUTPUT_ROOT: data
+      PUBLISH_RETENTION_DAYS: "7"
+      TZ: America/Sao_Paulo
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements-dev.txt
+
+      - name: Publish daily metagame snapshots
+        run: |
+          formats=()
+          for format in $PUBLISH_FORMATS; do
+            formats+=(--format "$format")
+          done
+
+          python -m publisher.runner \
+            --output-root "$PUBLISH_OUTPUT_ROOT" \
+            --retention-days "$PUBLISH_RETENTION_DAYS" \
+            scrape-metagame \
+            "${formats[@]}" \
+            --day "$(date +%F)"
+
+      - name: Prune retained working tree
+        run: |
+          python -m publisher.retention \
+            --output-root "$PUBLISH_OUTPUT_ROOT" \
+            --retention-days "$PUBLISH_RETENTION_DAYS"
+
+      - name: Commit changed snapshots
+        run: |
+          if [ -z "$(git status --porcelain -- "$PUBLISH_OUTPUT_ROOT")" ]; then
+            echo "No published data changes detected."
+            exit 0
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add "$PUBLISH_OUTPUT_ROOT"
+          git commit -m "Publish daily metagame snapshots"
+          git pull --rebase origin "${GITHUB_REF_NAME}"
+          git push origin HEAD:"${GITHUB_REF_NAME}"

--- a/.github/workflows/publish-hourly.yml
+++ b/.github/workflows/publish-hourly.yml
@@ -1,0 +1,71 @@
+name: Publish Hourly Snapshots
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "15 * * * *"
+
+permissions:
+  contents: write
+
+concurrency:
+  group: publish-data-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  publish-hourly:
+    runs-on: ubuntu-latest
+    env:
+      PUBLISH_FORMATS: "Modern Standard Pioneer Legacy Vintage Pauper"
+      PUBLISH_OUTPUT_ROOT: data
+      PUBLISH_RETENTION_DAYS: "7"
+      TZ: America/Sao_Paulo
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements-dev.txt
+
+      - name: Publish hourly deck and deck-text snapshots
+        run: |
+          formats=()
+          for format in $PUBLISH_FORMATS; do
+            formats+=(--format "$format")
+          done
+
+          python -m publisher.runner \
+            --output-root "$PUBLISH_OUTPUT_ROOT" \
+            --retention-days "$PUBLISH_RETENTION_DAYS" \
+            scrape-deck-texts \
+            "${formats[@]}" \
+            --days "$PUBLISH_RETENTION_DAYS"
+
+      - name: Prune retained working tree
+        run: |
+          python -m publisher.retention \
+            --output-root "$PUBLISH_OUTPUT_ROOT" \
+            --retention-days "$PUBLISH_RETENTION_DAYS"
+
+      - name: Commit changed snapshots
+        run: |
+          if [ -z "$(git status --porcelain -- "$PUBLISH_OUTPUT_ROOT")" ]; then
+            echo "No published data changes detected."
+            exit 0
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add "$PUBLISH_OUTPUT_ROOT"
+          git commit -m "Publish hourly scrape snapshots"
+          git pull --rebase origin "${GITHUB_REF_NAME}"
+          git push origin HEAD:"${GITHUB_REF_NAME}"

--- a/README.md
+++ b/README.md
@@ -55,6 +55,11 @@ Each publisher command also writes `data/latest/runs/<command>.json` with
 per-scope `success`, `skipped`, `stale-fallback`, and `hard-failure` statuses.
 Commands only return non-zero when freshness guarantees are violated.
 
+Checked-tree retention is one week. `data/hourly/` and `data/daily/` are pruned
+before automated commits, while `data/latest/` remains the stable consumer
+entrypoint. Git history is retained separately and is not rewritten by the
+publisher workflows.
+
 ## Publisher CLI
 
 The headless publisher entrypoint is `python -m publisher.runner`.
@@ -64,6 +69,7 @@ python -m publisher.runner --output-root data --timestamp 2026-03-23T12:00:00Z s
 python -m publisher.runner --output-root data --timestamp 2026-03-23T12:00:00Z scrape-decks --format Modern --archetype "Temur Rhinos" --days 7
 python -m publisher.runner --output-root data --timestamp 2026-03-23T12:00:00Z scrape-deck-texts --format Modern --archetype "Temur Rhinos" --days 7
 python -m publisher.runner --output-root data --timestamp 2026-03-23T12:00:00Z scrape-metagame --format Modern --day 2026-03-23
+python -m publisher.retention --output-root data --timestamp 2026-03-23T18:00:00Z --retention-days 7
 ```
 
 Outputs are written into repository-managed staging paths under `data/latest/`,
@@ -71,6 +77,17 @@ Outputs are written into repository-managed staging paths under `data/latest/`,
 Each command also writes `data/latest/runs/<command>.json`, with per-scope
 statuses (`success`, `skipped`, `stale-fallback`, `hard-failure`) and returns a
 non-zero exit code only when freshness guarantees are violated.
+
+## Publishing Schedules
+
+See [docs/publishing_workflows.md](docs/publishing_workflows.md) for the exact
+workflow behavior. In short:
+
+- Hourly publishing runs at minute `15` and writes deck metadata plus deck text
+  blobs for `Modern`, `Standard`, `Pioneer`, `Legacy`, `Vintage`, and `Pauper`.
+- Daily metagame publishing runs at `02:45` UTC, which is `23:45` in
+  `America/Sao_Paulo`.
+- Both workflows share a concurrency group and only push when `data/` changed.
 
 ## Development
 

--- a/docs/publishing_workflows.md
+++ b/docs/publishing_workflows.md
@@ -1,0 +1,22 @@
+# Publishing Workflows
+
+Scheduled publishing is split into two workflows:
+
+- `publish-hourly.yml` runs every hour at minute `15` and publishes the current
+  archetype/deck metadata plus referenced deck-text blobs for `Modern`,
+  `Standard`, `Pioneer`, `Legacy`, `Vintage`, and `Pauper`.
+- `publish-daily.yml` runs at `02:45` UTC, which is `23:45` in
+  `America/Sao_Paulo`, and publishes the daily metagame aggregate for the same
+  formats.
+
+Both workflows share the same concurrency group so only one publish job writes
+to `data/` at a time. Each workflow:
+
+1. Runs the publisher CLI.
+2. Prunes the checked-out tree with `python -m publisher.retention`.
+3. Commits and pushes `data/` only when the tree actually changed.
+
+Checked-tree retention is seven days for `data/hourly/` and `data/daily/`.
+`data/latest/` remains the stable consumer entrypoint, and deck-text blobs under
+`data/archive/` are pruned when they are no longer referenced by any retained or
+latest deck snapshot. Git history is not rewritten by this policy.

--- a/publisher/__init__.py
+++ b/publisher/__init__.py
@@ -9,11 +9,13 @@ from publisher.contracts import (
     validate_metagame_snapshot,
     validate_run_manifest,
 )
+from publisher.retention import prune_output_tree
 from publisher.runner import main
 
 __all__ = [
     "SCHEMA_VERSION",
     "main",
+    "prune_output_tree",
     "validate_archetype_deck_snapshot",
     "validate_archetype_list_snapshot",
     "validate_deck_text_blob",

--- a/publisher/retention.py
+++ b/publisher/retention.py
@@ -1,0 +1,219 @@
+"""Working-tree retention helpers for published scrape artifacts."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+from datetime import date, datetime, timedelta, timezone
+from pathlib import Path
+
+from publisher.contracts import build_latest_manifest, validate_latest_manifest
+from publisher.layout import DEFAULT_OUTPUT_ROOT, DEFAULT_RETENTION_DAYS, write_json
+
+try:
+    from datetime import UTC
+except ImportError:  # pragma: no cover - Python 3.10 fallback
+    UTC = timezone.utc  # noqa: UP017
+
+
+def _utc_now() -> str:
+    return datetime.now(UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _parse_timestamp(value: str) -> datetime:
+    return datetime.fromisoformat(value.replace("Z", "+00:00")).astimezone(UTC)
+
+
+def _parse_prune_timestamp(value: str | None) -> str:
+    if value:
+        return _parse_timestamp(value).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+    return _utc_now()
+
+
+def _parse_hourly_dir(name: str) -> datetime | None:
+    try:
+        day_token, time_token = name.split("T", 1)
+        hour, minute, second = time_token.removesuffix("Z").split("-", 2)
+        return _parse_timestamp(f"{day_token}T{hour}:{minute}:{second}Z")
+    except ValueError:
+        return None
+
+
+def _parse_daily_dir(name: str) -> date | None:
+    try:
+        return date.fromisoformat(name)
+    except ValueError:
+        return None
+
+
+def _deck_text_refs(snapshot_path: Path, *, output_root: Path) -> set[str]:
+    try:
+        payload = json.loads(snapshot_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return set()
+
+    refs: set[str] = set()
+    decks = payload.get("decks", [])
+    if not isinstance(decks, list):
+        return refs
+
+    for deck in decks:
+        if not isinstance(deck, dict):
+            continue
+        ref = deck.get("deck_text_path")
+        if isinstance(ref, str) and ref:
+            refs.add(ref)
+        elif isinstance(ref, Path):
+            refs.add(ref.relative_to(output_root).as_posix())
+    return refs
+
+
+def _prune_empty_parents(path: Path, *, stop_at: Path) -> None:
+    current = path
+    while current != stop_at and current.exists():
+        try:
+            current.rmdir()
+        except OSError:
+            return
+        current = current.parent
+
+
+def _existing_entries(output_root: Path, entries: list[dict[str, str]]) -> list[dict[str, str]]:
+    return [
+        entry
+        for entry in entries
+        if isinstance(entry.get("path"), str) and (output_root / entry["path"]).exists()
+    ]
+
+
+def _referenced_deck_text_paths(output_root: Path, retained_hourly_dirs: list[Path]) -> set[str]:
+    refs: set[str] = set()
+
+    latest_decks = output_root / "latest" / "decks"
+    if latest_decks.exists():
+        for snapshot_path in latest_decks.rglob("*.json"):
+            refs.update(_deck_text_refs(snapshot_path, output_root=output_root))
+
+    for hourly_dir in retained_hourly_dirs:
+        decks_dir = hourly_dir / "decks"
+        if not decks_dir.exists():
+            continue
+        for snapshot_path in decks_dir.rglob("*.json"):
+            refs.update(_deck_text_refs(snapshot_path, output_root=output_root))
+
+    return refs
+
+
+def prune_output_tree(
+    output_root: Path,
+    *,
+    generated_at: str | None = None,
+    retention_days: int = DEFAULT_RETENTION_DAYS,
+) -> dict[str, int]:
+    if retention_days < 1:
+        raise ValueError("retention_days must be at least 1")
+
+    normalized_generated_at = _parse_prune_timestamp(generated_at)
+    cutoff_ts = _parse_timestamp(normalized_generated_at) - timedelta(days=retention_days)
+    cutoff_day = cutoff_ts.date()
+
+    summary = {
+        "hourly_dirs_removed": 0,
+        "daily_dirs_removed": 0,
+        "deck_text_blobs_removed": 0,
+        "deck_text_manifest_entries_removed": 0,
+    }
+
+    retained_hourly_dirs: list[Path] = []
+    hourly_root = output_root / "hourly"
+    if hourly_root.exists():
+        for path in sorted(hourly_root.iterdir()):
+            if not path.is_dir():
+                continue
+            parsed = _parse_hourly_dir(path.name)
+            if parsed is not None and parsed < cutoff_ts:
+                shutil.rmtree(path)
+                summary["hourly_dirs_removed"] += 1
+                continue
+            retained_hourly_dirs.append(path)
+
+    daily_root = output_root / "daily"
+    if daily_root.exists():
+        for path in sorted(daily_root.iterdir()):
+            if not path.is_dir():
+                continue
+            parsed = _parse_daily_dir(path.name)
+            if parsed is not None and parsed < cutoff_day:
+                shutil.rmtree(path)
+                summary["daily_dirs_removed"] += 1
+
+    deck_text_refs = _referenced_deck_text_paths(output_root, retained_hourly_dirs)
+    archive_root = output_root / "archive" / "deck-texts"
+    if archive_root.exists():
+        for path in sorted(archive_root.rglob("*.json")):
+            relative_path = path.relative_to(output_root).as_posix()
+            if relative_path in deck_text_refs:
+                continue
+            path.unlink()
+            summary["deck_text_blobs_removed"] += 1
+            _prune_empty_parents(path.parent, stop_at=archive_root)
+
+    manifest_path = output_root / "latest" / "latest.json"
+    if manifest_path.exists():
+        manifest = validate_latest_manifest(json.loads(manifest_path.read_text(encoding="utf-8")))
+    else:
+        manifest = build_latest_manifest(
+            generated_at=normalized_generated_at,
+            retention_days=retention_days,
+        )
+
+    manifest["generated_at"] = normalized_generated_at
+    manifest["retention_days"] = retention_days
+    manifest["latest"]["archetype_lists"] = _existing_entries(
+        output_root, manifest["latest"].get("archetype_lists", [])
+    )
+    manifest["latest"]["archetype_decks"] = _existing_entries(
+        output_root, manifest["latest"].get("archetype_decks", [])
+    )
+    manifest["latest"]["metagame_daily"] = _existing_entries(
+        output_root, manifest["latest"].get("metagame_daily", [])
+    )
+    manifest["latest"]["runs"] = _existing_entries(output_root, manifest["latest"].get("runs", []))
+
+    existing_deck_entries = manifest["latest"].get("deck_text_blobs", [])
+    manifest["latest"]["deck_text_blobs"] = [
+        entry
+        for entry in _existing_entries(output_root, existing_deck_entries)
+        if entry["path"] in deck_text_refs
+    ]
+    summary["deck_text_manifest_entries_removed"] = len(existing_deck_entries) - len(
+        manifest["latest"]["deck_text_blobs"]
+    )
+
+    write_json(manifest_path, manifest)
+    return summary
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Prune publisher working-tree artifacts")
+    parser.add_argument("--output-root", default=str(DEFAULT_OUTPUT_ROOT))
+    parser.add_argument("--timestamp", help="UTC timestamp used for retention cutoff")
+    parser.add_argument("--retention-days", type=int, default=DEFAULT_RETENTION_DAYS)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    summary = prune_output_tree(
+        Path(args.output_root),
+        generated_at=args.timestamp,
+        retention_days=args.retention_days,
+    )
+    print(json.dumps(summary, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/tests/test_publisher_retention.py
+++ b/tests/test_publisher_retention.py
@@ -1,0 +1,112 @@
+import json
+
+from publisher.contracts import build_latest_manifest
+from publisher.layout import write_json
+from publisher.retention import prune_output_tree
+
+NOW = "2026-03-23T18:00:00Z"
+
+
+def _write_snapshot(path, payload):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    write_json(path, payload)
+
+
+def test_prune_output_tree_removes_old_snapshots_and_unreferenced_deck_texts(tmp_path):
+    retained_hourly = tmp_path / "hourly" / "2026-03-23T12-00-00Z" / "decks" / "modern"
+    expired_hourly = tmp_path / "hourly" / "2026-03-15T12-00-00Z" / "decks" / "modern"
+    retained_daily = tmp_path / "daily" / "2026-03-20" / "metagame"
+    expired_daily = tmp_path / "daily" / "2026-03-10" / "metagame"
+
+    _write_snapshot(
+        tmp_path / "latest" / "decks" / "modern" / "temur-rhinos.json",
+        {
+            "decks": [
+                {
+                    "number": "123",
+                    "deck_text_path": "archive/deck-texts/modern/123.json",
+                }
+            ]
+        },
+    )
+    _write_snapshot(
+        retained_hourly / "temur-rhinos.json",
+        {
+            "decks": [
+                {
+                    "number": "123",
+                    "deck_text_path": "archive/deck-texts/modern/123.json",
+                }
+            ]
+        },
+    )
+    _write_snapshot(
+        expired_hourly / "old-snapshot.json",
+        {
+            "decks": [
+                {
+                    "number": "999",
+                    "deck_text_path": "archive/deck-texts/modern/999.json",
+                }
+            ]
+        },
+    )
+    _write_snapshot(retained_daily / "modern.json", {"stats": []})
+    _write_snapshot(expired_daily / "modern.json", {"stats": []})
+    _write_snapshot(
+        tmp_path / "archive" / "deck-texts" / "modern" / "123.json", {"deck_text": "keep"}
+    )
+    _write_snapshot(
+        tmp_path / "archive" / "deck-texts" / "modern" / "999.json", {"deck_text": "drop"}
+    )
+
+    manifest = build_latest_manifest(generated_at=NOW, retention_days=7)
+    manifest["latest"]["archetype_decks"].append(
+        {
+            "format": "modern",
+            "archetype": "temur-rhinos",
+            "path": "latest/decks/modern/temur-rhinos.json",
+            "updated_at": NOW,
+        }
+    )
+    manifest["latest"]["deck_text_blobs"].extend(
+        [
+            {
+                "format": "modern",
+                "deck_id": "123",
+                "path": "archive/deck-texts/modern/123.json",
+                "updated_at": NOW,
+            },
+            {
+                "format": "modern",
+                "deck_id": "999",
+                "path": "archive/deck-texts/modern/999.json",
+                "updated_at": NOW,
+            },
+        ]
+    )
+    _write_snapshot(tmp_path / "latest" / "latest.json", manifest)
+
+    summary = prune_output_tree(tmp_path, generated_at=NOW, retention_days=7)
+
+    assert summary["hourly_dirs_removed"] == 1
+    assert summary["daily_dirs_removed"] == 1
+    assert summary["deck_text_blobs_removed"] == 1
+    assert summary["deck_text_manifest_entries_removed"] == 1
+    assert (tmp_path / "hourly" / "2026-03-23T12-00-00Z").exists()
+    assert not (tmp_path / "hourly" / "2026-03-15T12-00-00Z").exists()
+    assert (tmp_path / "daily" / "2026-03-20").exists()
+    assert not (tmp_path / "daily" / "2026-03-10").exists()
+    assert (tmp_path / "archive" / "deck-texts" / "modern" / "123.json").exists()
+    assert not (tmp_path / "archive" / "deck-texts" / "modern" / "999.json").exists()
+
+    latest_manifest = json.loads((tmp_path / "latest" / "latest.json").read_text(encoding="utf-8"))
+    assert latest_manifest["retention_days"] == 7
+    assert latest_manifest["latest"]["deck_text_blobs"] == [
+        {
+            "format": "modern",
+            "deck_id": "123",
+            "path": "archive/deck-texts/modern/123.json",
+            "updated_at": NOW,
+        }
+    ]


### PR DESCRIPTION
## Summary
- add hourly and daily GitHub Actions workflows for publisher snapshots
- add a retention cleanup module that prunes old hourly/daily trees and unreferenced deck-text blobs
- document the schedules and retention policy and cover cleanup behavior with tests

## Testing
- python3 -m ruff check .
- python3 -m black --check .
- python3 -m pytest tests/test_publisher_contracts.py tests/test_publisher_runner.py tests/test_publisher_retention.py tests/test_scraping_surface.py

Closes #1