### PR TITLE
Throttle deck downloads and preserve partial publish commits

### DIFF
--- a/.github/workflows/publish-daily.yml
+++ b/.github/workflows/publish-daily.yml
@@ -38,18 +38,23 @@ jobs:
           pip install -r requirements-dev.txt
 
       - name: Publish daily metagame snapshots
+        id: publish
         run: |
           formats=()
           for format in $PUBLISH_FORMATS; do
             formats+=(--format "$format")
           done
 
+          set +e
           python -m publisher.runner \
             --output-root "$PUBLISH_OUTPUT_ROOT" \
             --retention-days "$PUBLISH_RETENTION_DAYS" \
             scrape-metagame \
             "${formats[@]}" \
             --day "$(date +%F)"
+          exit_code=$?
+          echo "exit_code=$exit_code" >> "$GITHUB_OUTPUT"
+          exit 0
 
       - name: Prune retained working tree
         run: |
@@ -70,3 +75,9 @@ jobs:
           git commit -m "Publish daily metagame snapshots"
           git pull --rebase origin "${GITHUB_REF_NAME}"
           git push origin HEAD:"${GITHUB_REF_NAME}"
+
+      - name: Fail if freshness guarantees were violated
+        if: steps.publish.outputs.exit_code != '0'
+        run: |
+          echo "Publisher exited with code ${{ steps.publish.outputs.exit_code }}."
+          exit 1

--- a/.github/workflows/publish-hourly.yml
+++ b/.github/workflows/publish-hourly.yml
@@ -19,6 +19,7 @@ jobs:
       PUBLISH_FORMATS: "Modern Standard Pioneer Legacy Vintage Pauper"
       PUBLISH_OUTPUT_ROOT: data
       PUBLISH_RETENTION_DAYS: "7"
+      PUBLISH_DECK_DOWNLOAD_DELAY_SECONDS: "3"
       TZ: America/Sao_Paulo
     steps:
       - name: Check out repository
@@ -37,18 +38,24 @@ jobs:
           pip install -r requirements-dev.txt
 
       - name: Publish hourly deck and deck-text snapshots
+        id: publish
         run: |
           formats=()
           for format in $PUBLISH_FORMATS; do
             formats+=(--format "$format")
           done
 
+          set +e
           python -m publisher.runner \
             --output-root "$PUBLISH_OUTPUT_ROOT" \
             --retention-days "$PUBLISH_RETENTION_DAYS" \
             scrape-deck-texts \
             "${formats[@]}" \
+            --deck-download-delay-seconds "$PUBLISH_DECK_DOWNLOAD_DELAY_SECONDS" \
             --days "$PUBLISH_RETENTION_DAYS"
+          exit_code=$?
+          echo "exit_code=$exit_code" >> "$GITHUB_OUTPUT"
+          exit 0
 
       - name: Prune retained working tree
         run: |
@@ -69,3 +76,9 @@ jobs:
           git commit -m "Publish hourly scrape snapshots"
           git pull --rebase origin "${GITHUB_REF_NAME}"
           git push origin HEAD:"${GITHUB_REF_NAME}"
+
+      - name: Fail if freshness guarantees were violated
+        if: steps.publish.outputs.exit_code != '0'
+        run: |
+          echo "Publisher exited with code ${{ steps.publish.outputs.exit_code }}."
+          exit 1

--- a/publisher/runner.py
+++ b/publisher/runner.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import time
 from collections import Counter
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
@@ -47,6 +48,7 @@ STATUS_SKIPPED = "skipped"
 STATUS_STALE_FALLBACK = "stale-fallback"
 STATUS_HARD_FAILURE = "hard-failure"
 HARD_FAILURE_STATES = {STATUS_HARD_FAILURE}
+DEFAULT_DECK_DOWNLOAD_DELAY_SECONDS = 0.0
 
 
 def _utc_now() -> str:
@@ -494,6 +496,7 @@ def _write_deck_text_blobs(
     archetype_filters: list[str] | None,
     days: int | None,
     source_filter: str | None,
+    deck_download_delay_seconds: float,
 ) -> None:
     repo = ScrapingMetagameRepository()
     normalized_format = normalize_name(format_name)
@@ -522,9 +525,16 @@ def _write_deck_text_blobs(
         )
         return
 
-    for deck_id, deck in sorted(unique_decks.items()):
+    for index, (deck_id, deck) in enumerate(sorted(unique_decks.items())):
         archive_path = _deck_text_archive_path(output_root, normalized_format, deck_id)
         try:
+            if index > 0 and deck_download_delay_seconds > 0:
+                logger.info(
+                    "Sleeping {} seconds before downloading deck {}",
+                    deck_download_delay_seconds,
+                    deck_id,
+                )
+                time.sleep(deck_download_delay_seconds)
             deck_text = repo.download_deck_content(deck, source_filter=source_filter)
             snapshot = build_deck_text_blob(
                 generated_at=generated_at,
@@ -594,6 +604,11 @@ def build_parser() -> argparse.ArgumentParser:
     deck_texts.add_argument("--archetype", dest="archetypes", action="append")
     deck_texts.add_argument("--days", type=int)
     deck_texts.add_argument(
+        "--deck-download-delay-seconds",
+        type=float,
+        default=DEFAULT_DECK_DOWNLOAD_DELAY_SECONDS,
+    )
+    deck_texts.add_argument(
         "--source-filter", choices=["mtggoldfish", "mtgo", "both"], default="both"
     )
 
@@ -650,6 +665,7 @@ def main(argv: list[str] | None = None) -> int:
                 archetype_filters=args.archetypes,
                 days=args.days,
                 source_filter=None if args.source_filter == "both" else args.source_filter,
+                deck_download_delay_seconds=args.deck_download_delay_seconds,
             )
     elif args.command == "scrape-decks":
         for format_name in args.formats:

--- a/tests/test_publisher_runner.py
+++ b/tests/test_publisher_runner.py
@@ -201,3 +201,54 @@ def test_scrape_deck_texts_deduplicates_by_deck_id(monkeypatch, tmp_path):
     assert blob["deck_text"] == "Deck 123"
     assert len(manifest["latest"]["deck_text_blobs"]) == 1
     assert manifest["latest"]["deck_text_blobs"][0]["path"] == "archive/deck-texts/modern/123.json"
+
+
+def test_scrape_deck_texts_sleeps_between_unique_downloads(monkeypatch, tmp_path):
+    monkeypatch.setattr(
+        "publisher.runner.fetch_archetypes",
+        lambda *args, **kwargs: [{"name": "Temur Rhinos", "href": "modern-temur-rhinos"}],
+    )
+
+    class _MultiDeckRepo(_FakeRepo):
+        def get_decks_for_archetype(self, archetype, force_refresh=False, source_filter=None):
+            return [
+                {
+                    "name": archetype["name"],
+                    "number": "123",
+                    "date": "2026-03-22",
+                    "player": "Alice",
+                    "event": "Modern Challenge",
+                    "source": "mtggoldfish",
+                },
+                {
+                    "name": archetype["name"],
+                    "number": "456",
+                    "date": "2026-03-22",
+                    "player": "Bob",
+                    "event": "Modern Challenge",
+                    "source": "mtggoldfish",
+                },
+            ]
+
+    sleeps: list[float] = []
+    monkeypatch.setattr("publisher.runner.ScrapingMetagameRepository", _MultiDeckRepo)
+    monkeypatch.setattr("publisher.runner.time.sleep", sleeps.append)
+
+    exit_code = main(
+        [
+            "--output-root",
+            str(tmp_path),
+            "--timestamp",
+            TIMESTAMP,
+            "scrape-deck-texts",
+            "--format",
+            "Modern",
+            "--days",
+            "7",
+            "--deck-download-delay-seconds",
+            "3",
+        ]
+    )
+
+    assert exit_code == 0
+    assert sleeps == [3.0]


### PR DESCRIPTION
## Summary
- add a configurable delay between deck-text downloads and set the hourly workflow to use 3 seconds
- let publish workflows keep running after a non-zero publisher exit so retention and data commits still happen
- fail the workflow after the commit step when freshness guarantees were violated

## Testing
- python3 -m ruff check .
- python3 -m black --check .
- python3 -m pytest tests/test_publisher_runner.py tests/test_publisher_retention.py tests/test_publisher_contracts.py tests/test_scraping_surface.py