### PR TITLE
Reuse published deck text blobs across runs

### DIFF
--- a/publisher/runner.py
+++ b/publisher/runner.py
@@ -90,6 +90,21 @@ def _load_json_if_present(path: Path) -> dict[str, Any] | None:
         return json.load(fh)
 
 
+def _load_reusable_deck_text_blob(
+    path: Path, *, format_name: str, deck_id: str
+) -> dict[str, Any] | None:
+    payload = _load_json_if_present(path)
+    if not payload:
+        return None
+    try:
+        validated = validate_deck_text_blob(payload)
+    except ValueError:
+        return None
+    if validated.get("format") != format_name or validated.get("deck_id") != deck_id:
+        return None
+    return validated
+
+
 def _is_path_fresh(path: Path, *, generated_at: str, max_stale_hours: int) -> bool:
     payload = _load_json_if_present(path)
     if not payload:
@@ -528,6 +543,29 @@ def _write_deck_text_blobs(
     for index, (deck_id, deck) in enumerate(sorted(unique_decks.items())):
         archive_path = _deck_text_archive_path(output_root, normalized_format, deck_id)
         try:
+            reused_blob = _load_reusable_deck_text_blob(
+                archive_path,
+                format_name=normalized_format,
+                deck_id=deck_id,
+            )
+            if reused_blob is not None:
+                update_latest_manifest(
+                    output_root,
+                    generated_at=generated_at,
+                    retention_days=recorder.retention_days,
+                    category="deck_text_blobs",
+                    discriminator={"format": normalized_format, "deck_id": deck_id},
+                    relative_path=relative_posix_path(archive_path, output_root),
+                )
+                recorder.add(
+                    scope="deck-text",
+                    status=STATUS_SKIPPED,
+                    format_name=normalized_format,
+                    deck_id=deck_id,
+                    path=relative_posix_path(archive_path, output_root),
+                    message="Reused existing published deck-text blob.",
+                )
+                continue
             if index > 0 and deck_download_delay_seconds > 0:
                 logger.info(
                     "Sleeping {} seconds before downloading deck {}",

--- a/tests/test_publisher_runner.py
+++ b/tests/test_publisher_runner.py
@@ -252,3 +252,61 @@ def test_scrape_deck_texts_sleeps_between_unique_downloads(monkeypatch, tmp_path
 
     assert exit_code == 0
     assert sleeps == [3.0]
+
+
+def test_scrape_deck_texts_reuses_existing_published_blob(monkeypatch, tmp_path):
+    monkeypatch.setattr(
+        "publisher.runner.fetch_archetypes",
+        lambda *args, **kwargs: [{"name": "Temur Rhinos", "href": "modern-temur-rhinos"}],
+    )
+    monkeypatch.setattr("publisher.runner.ScrapingMetagameRepository", _FakeRepo)
+
+    archive_path = tmp_path / "archive" / "deck-texts" / "modern" / "123.json"
+    archive_path.parent.mkdir(parents=True, exist_ok=True)
+    archive_path.write_text(
+        json.dumps(
+            {
+                "schema_version": "1",
+                "kind": "deck_text_blob",
+                "generated_at": "2026-03-22T12:00:00Z",
+                "format": "modern",
+                "source": "mtggoldfish",
+                "deck_id": "123",
+                "deck_name": "Temur Rhinos",
+                "deck_text": "Deck 123",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    sleeps: list[float] = []
+    monkeypatch.setattr("publisher.runner.time.sleep", sleeps.append)
+
+    def _boom(*args, **kwargs):
+        raise AssertionError("download_deck_content should not be called for reused blobs")
+
+    monkeypatch.setattr(_FakeRepo, "download_deck_content", _boom)
+
+    exit_code = main(
+        [
+            "--output-root",
+            str(tmp_path),
+            "--timestamp",
+            TIMESTAMP,
+            "scrape-deck-texts",
+            "--format",
+            "Modern",
+            "--days",
+            "7",
+            "--deck-download-delay-seconds",
+            "3",
+        ]
+    )
+
+    assert exit_code == 0
+    assert sleeps == []
+    run_manifest = json.loads(
+        (tmp_path / "latest" / "runs" / "scrape-deck-texts.json").read_text(encoding="utf-8")
+    )
+    assert run_manifest["results"][-1]["status"] == "skipped"
+    assert run_manifest["results"][-1]["message"] == "Reused existing published deck-text blob."


### PR DESCRIPTION
## Summary
- reuse existing published deck-text blobs from `data/archive/` instead of redownloading the same deck ids each run
- refresh the latest manifest pointer when a blob is reused
- add coverage to ensure reused blobs skip both the sleep and the network download path

## Testing
- python3 -m ruff check .
- python3 -m black --check .
- python3 -m pytest tests/test_publisher_runner.py tests/test_publisher_retention.py tests/test_publisher_contracts.py tests/test_scraping_surface.py