### PR TITLE
Split scheduled publish jobs by format

### DIFF
--- a/.github/workflows/publish-daily.yml
+++ b/.github/workflows/publish-daily.yml
@@ -10,17 +10,23 @@ permissions:
   contents: write
 
 concurrency:
-  group: publish-data-${{ github.ref }}
+  group: publish-daily-workflow-${{ github.ref }}
   cancel-in-progress: false
 
 jobs:
   publish-daily:
+    strategy:
+      fail-fast: false
+      matrix:
+        format: [Modern, Standard, Pioneer, Legacy, Vintage, Pauper]
     runs-on: ubuntu-latest
     env:
-      PUBLISH_FORMATS: "Modern Standard Pioneer Legacy Vintage Pauper"
       PUBLISH_OUTPUT_ROOT: data
       PUBLISH_RETENTION_DAYS: "7"
       TZ: America/Sao_Paulo
+    concurrency:
+      group: publish-daily-${{ github.ref }}-${{ matrix.format }}
+      cancel-in-progress: false
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -40,17 +46,12 @@ jobs:
       - name: Publish daily metagame snapshots
         id: publish
         run: |
-          formats=()
-          for format in $PUBLISH_FORMATS; do
-            formats+=(--format "$format")
-          done
-
           set +e
           python -m publisher.runner \
             --output-root "$PUBLISH_OUTPUT_ROOT" \
             --retention-days "$PUBLISH_RETENTION_DAYS" \
             scrape-metagame \
-            "${formats[@]}" \
+            --format "${{ matrix.format }}" \
             --day "$(date +%F)"
           exit_code=$?
           echo "exit_code=$exit_code" >> "$GITHUB_OUTPUT"
@@ -72,7 +73,7 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add "$PUBLISH_OUTPUT_ROOT"
-          git commit -m "Publish daily metagame snapshots"
+          git commit -m "Publish daily metagame snapshots for ${{ matrix.format }}"
           git pull --rebase origin "${GITHUB_REF_NAME}"
           git push origin HEAD:"${GITHUB_REF_NAME}"
 

--- a/.github/workflows/publish-hourly.yml
+++ b/.github/workflows/publish-hourly.yml
@@ -9,18 +9,24 @@ permissions:
   contents: write
 
 concurrency:
-  group: publish-data-${{ github.ref }}
+  group: publish-hourly-workflow-${{ github.ref }}
   cancel-in-progress: false
 
 jobs:
   publish-hourly:
+    strategy:
+      fail-fast: false
+      matrix:
+        format: [Modern, Standard, Pioneer, Legacy, Vintage, Pauper]
     runs-on: ubuntu-latest
     env:
-      PUBLISH_FORMATS: "Modern Standard Pioneer Legacy Vintage Pauper"
       PUBLISH_OUTPUT_ROOT: data
       PUBLISH_RETENTION_DAYS: "7"
       PUBLISH_DECK_DOWNLOAD_DELAY_SECONDS: "3"
       TZ: America/Sao_Paulo
+    concurrency:
+      group: publish-hourly-${{ github.ref }}-${{ matrix.format }}
+      cancel-in-progress: false
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -40,17 +46,12 @@ jobs:
       - name: Publish hourly deck and deck-text snapshots
         id: publish
         run: |
-          formats=()
-          for format in $PUBLISH_FORMATS; do
-            formats+=(--format "$format")
-          done
-
           set +e
           python -m publisher.runner \
             --output-root "$PUBLISH_OUTPUT_ROOT" \
             --retention-days "$PUBLISH_RETENTION_DAYS" \
             scrape-deck-texts \
-            "${formats[@]}" \
+            --format "${{ matrix.format }}" \
             --deck-download-delay-seconds "$PUBLISH_DECK_DOWNLOAD_DELAY_SECONDS" \
             --days "$PUBLISH_RETENTION_DAYS"
           exit_code=$?
@@ -73,7 +74,7 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add "$PUBLISH_OUTPUT_ROOT"
-          git commit -m "Publish hourly scrape snapshots"
+          git commit -m "Publish hourly scrape snapshots for ${{ matrix.format }}"
           git pull --rebase origin "${GITHUB_REF_NAME}"
           git push origin HEAD:"${GITHUB_REF_NAME}"
 

--- a/README.md
+++ b/README.md
@@ -83,11 +83,13 @@ non-zero exit code only when freshness guarantees are violated.
 See [docs/publishing_workflows.md](docs/publishing_workflows.md) for the exact
 workflow behavior. In short:
 
-- Hourly publishing runs at minute `15` and writes deck metadata plus deck text
-  blobs for `Modern`, `Standard`, `Pioneer`, `Legacy`, `Vintage`, and `Pauper`.
+- Hourly publishing runs at minute `15` and fans out into one job per format,
+  writing deck metadata plus deck text blobs for `Modern`, `Standard`,
+  `Pioneer`, `Legacy`, `Vintage`, and `Pauper`.
 - Daily metagame publishing runs at `02:45` UTC, which is `23:45` in
-  `America/Sao_Paulo`.
-- Both workflows share a concurrency group and only push when `data/` changed.
+  `America/Sao_Paulo`, also as one job per format.
+- Each format job has its own concurrency key and only pushes when `data/`
+  changed.
 
 ## Development
 

--- a/docs/publishing_workflows.md
+++ b/docs/publishing_workflows.md
@@ -2,15 +2,17 @@
 
 Scheduled publishing is split into two workflows:
 
-- `publish-hourly.yml` runs every hour at minute `15` and publishes the current
-  archetype/deck metadata plus referenced deck-text blobs for `Modern`,
-  `Standard`, `Pioneer`, `Legacy`, `Vintage`, and `Pauper`.
+- `publish-hourly.yml` runs every hour at minute `15` and fans out into one job
+  per format for `Modern`, `Standard`, `Pioneer`, `Legacy`, `Vintage`, and
+  `Pauper`. Each job publishes current archetype/deck metadata plus referenced
+  deck-text blobs for just that format.
 - `publish-daily.yml` runs at `02:45` UTC, which is `23:45` in
-  `America/Sao_Paulo`, and publishes the daily metagame aggregate for the same
-  formats.
+  `America/Sao_Paulo`, and also fans out into one job per format for the daily
+  metagame aggregate.
 
-Both workflows share the same concurrency group so only one publish job writes
-to `data/` at a time. Each workflow:
+Each format job has its own concurrency group, so a new `Modern` run can block
+or wait on another `Modern` run without cancelling unrelated formats. Each
+workflow job:
 
 1. Runs the publisher CLI.
 2. Prunes the checked-out tree with `python -m publisher.retention`.


### PR DESCRIPTION
## Summary
- change hourly publishing to run one matrix job per format instead of scraping all formats in one job
- change daily metagame publishing to run one matrix job per format as well
- update docs to reflect per-format job fanout and per-format concurrency keys

## Testing
- python3 -m ruff check .
- python3 -m black --check .