### PR TITLE
Avoid publish-hourly merge conflicts

### DIFF
--- a/.github/workflows/publish-hourly.yml
+++ b/.github/workflows/publish-hourly.yml
@@ -3,7 +3,7 @@ name: Publish Hourly Snapshots
 on:
   workflow_dispatch:
   schedule:
-    - cron: "15 * * * *"
+    - cron: "15 */2 * * *"
 
 permissions:
   contents: write
@@ -58,11 +58,172 @@ jobs:
           echo "exit_code=$exit_code" >> "$GITHUB_OUTPUT"
           exit 0
 
+      - name: Package format artifact
+        if: always()
+        env:
+          MATRIX_FORMAT: ${{ matrix.format }}
+        run: |
+          python - <<'PY'
+          import os
+          import shutil
+          from pathlib import Path
+
+          from publisher.layout import normalize_name
+
+          data_root = Path(os.environ["PUBLISH_OUTPUT_ROOT"])
+          artifact_root = Path("artifact")
+          normalized_format = normalize_name(os.environ["MATRIX_FORMAT"])
+          artifact_root.mkdir(parents=True, exist_ok=True)
+
+          def copy_path(path: Path) -> None:
+              if not path.exists():
+                  return
+              if path.is_dir():
+                  for child in path.rglob("*"):
+                      if child.is_file():
+                          destination = artifact_root / child.relative_to(data_root)
+                          destination.parent.mkdir(parents=True, exist_ok=True)
+                          shutil.copy2(child, destination)
+                  return
+              destination = artifact_root / path.relative_to(data_root)
+              destination.parent.mkdir(parents=True, exist_ok=True)
+              shutil.copy2(path, destination)
+
+          copy_path(data_root / "latest" / "archetypes" / f"{normalized_format}.json")
+          copy_path(data_root / "latest" / "decks" / normalized_format)
+          copy_path(data_root / "latest" / "runs" / f"scrape-deck-texts-{normalized_format}.json")
+          copy_path(data_root / "archive" / "deck-texts" / normalized_format)
+
+          hourly_root = data_root / "hourly"
+          if hourly_root.exists():
+              for snapshot_dir in hourly_root.iterdir():
+                  if not snapshot_dir.is_dir():
+                      continue
+                  copy_path(snapshot_dir / "archetypes" / f"{normalized_format}.json")
+                  copy_path(snapshot_dir / "decks" / normalized_format)
+                  copy_path(snapshot_dir / "runs" / f"scrape-deck-texts-{normalized_format}.json")
+
+          metadata_path = artifact_root / ".artifact-format"
+          metadata_path.write_text(f"{normalized_format}\n", encoding="utf-8")
+          PY
+
+      - name: Upload format artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: publish-hourly-${{ matrix.format }}
+          path: artifact
+          if-no-files-found: error
+
+      - name: Fail if freshness guarantees were violated
+        if: steps.publish.outputs.exit_code != '0'
+        run: |
+          echo "Publisher exited with code ${{ steps.publish.outputs.exit_code }}."
+          exit 1
+
+  commit-hourly:
+    needs: publish-hourly
+    if: always()
+    runs-on: ubuntu-latest
+    env:
+      PUBLISH_OUTPUT_ROOT: data
+      PUBLISH_RETENTION_DAYS: "7"
+      TZ: America/Sao_Paulo
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements-dev.txt
+
+      - name: Download format artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: publish-hourly-*
+          merge-multiple: true
+          path: .
+
       - name: Prune retained working tree
         run: |
           python -m publisher.retention \
             --output-root "$PUBLISH_OUTPUT_ROOT" \
             --retention-days "$PUBLISH_RETENTION_DAYS"
+
+      - name: Rebuild latest manifest
+        run: |
+          python - <<'PY'
+          from datetime import UTC, datetime
+          import json
+          import os
+          from pathlib import Path
+
+          from publisher.contracts import build_latest_manifest
+          from publisher.layout import normalize_name, write_json
+
+          output_root = Path(os.environ["PUBLISH_OUTPUT_ROOT"])
+          retention_days = int(os.environ["PUBLISH_RETENTION_DAYS"])
+          generated_at = datetime.now(UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+          manifest = build_latest_manifest(generated_at=generated_at, retention_days=retention_days)
+
+          def load_payload(path: Path) -> dict:
+              return json.loads(path.read_text(encoding="utf-8"))
+
+          def relative_path(path: Path) -> str:
+              return path.relative_to(output_root).as_posix()
+
+          def append_entry(category: str, path: Path, format_value: str | None = None, **extra: str) -> None:
+              payload = load_payload(path)
+              manifest["latest"][category].append(
+                  {
+                      "format": format_value or payload.get("format") or path.stem,
+                      "path": relative_path(path),
+                      "updated_at": payload.get("generated_at", generated_at),
+                      **extra,
+                  }
+              )
+
+          for path in sorted((output_root / "latest" / "archetypes").glob("*.json")):
+              append_entry("archetype_lists", path)
+
+          for path in sorted((output_root / "latest" / "decks").rglob("*.json")):
+              payload = load_payload(path)
+              archetype = payload.get("archetype", {})
+              append_entry(
+                  "archetype_decks",
+                  path,
+                  archetype=normalize_name(archetype.get("name", path.stem)),
+              )
+
+          for path in sorted((output_root / "latest" / "metagame").glob("*.json")):
+              append_entry("metagame_daily", path)
+
+          for path in sorted((output_root / "archive" / "deck-texts").rglob("*.json")):
+              payload = load_payload(path)
+              append_entry(
+                  "deck_text_blobs",
+                  path,
+                  deck_id=str(payload.get("deck_id", path.stem)),
+              )
+
+          for path in sorted((output_root / "latest" / "runs").glob("*.json")):
+              payload = load_payload(path)
+              append_entry(
+                  "runs",
+                  path,
+                  format_value=payload.get("command", path.stem),
+              )
+
+          write_json(output_root / "latest" / "latest.json", manifest)
+          PY
 
       - name: Commit changed snapshots
         run: |
@@ -74,12 +235,11 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add "$PUBLISH_OUTPUT_ROOT"
-          git commit -m "Publish hourly scrape snapshots for ${{ matrix.format }}"
-          git pull --rebase origin "${GITHUB_REF_NAME}"
+          git commit -m "Publish hourly scrape snapshots"
           git push origin HEAD:"${GITHUB_REF_NAME}"
 
-      - name: Fail if freshness guarantees were violated
-        if: steps.publish.outputs.exit_code != '0'
+      - name: Fail if any format missed freshness guarantees
+        if: needs.publish-hourly.result != 'success'
         run: |
-          echo "Publisher exited with code ${{ steps.publish.outputs.exit_code }}."
+          echo "One or more hourly format jobs failed freshness guarantees."
           exit 1

--- a/README.md
+++ b/README.md
@@ -51,9 +51,11 @@ Publisher outputs are written under `data/`:
 - `data/archive/deck-texts/<format>/<deck-id>.json` for deduplicated per-deck
   text blobs referenced from deck metadata snapshots.
 
-Each publisher command also writes `data/latest/runs/<command>.json` with
-per-scope `success`, `skipped`, `stale-fallback`, and `hard-failure` statuses.
-Commands only return non-zero when freshness guarantees are violated.
+Each publisher command also writes a run manifest under `data/latest/runs/`.
+Single-format runs use `data/latest/runs/<command>-<format>.json`; multi-format
+runs keep `data/latest/runs/<command>.json`. These manifests record per-scope
+`success`, `skipped`, `stale-fallback`, and `hard-failure` statuses. Commands
+only return non-zero when freshness guarantees are violated.
 
 Checked-tree retention is one week. `data/hourly/` and `data/daily/` are pruned
 before automated commits, while `data/latest/` remains the stable consumer
@@ -74,22 +76,25 @@ python -m publisher.retention --output-root data --timestamp 2026-03-23T18:00:00
 
 Outputs are written into repository-managed staging paths under `data/latest/`,
 `data/hourly/`, `data/daily/`, and `data/archive/`.
-Each command also writes `data/latest/runs/<command>.json`, with per-scope
-statuses (`success`, `skipped`, `stale-fallback`, `hard-failure`) and returns a
-non-zero exit code only when freshness guarantees are violated.
+Each command also writes a run manifest under `data/latest/runs/`. Single-format
+runs use `data/latest/runs/<command>-<format>.json`; multi-format runs keep
+`data/latest/runs/<command>.json`. These manifests store per-scope statuses
+(`success`, `skipped`, `stale-fallback`, `hard-failure`) and the command only
+returns a non-zero exit code when freshness guarantees are violated.
 
 ## Publishing Schedules
 
 See [docs/publishing_workflows.md](docs/publishing_workflows.md) for the exact
 workflow behavior. In short:
 
-- Hourly publishing runs at minute `15` and fans out into one job per format,
-  writing deck metadata plus deck text blobs for `Modern`, `Standard`,
-  `Pioneer`, `Legacy`, `Vintage`, and `Pauper`.
+- Hourly publishing runs every two hours at minute `15`, fans out into one job
+  per format, uploads per-format artifacts, then commits the merged result once
+  after all format jobs finish. It writes deck metadata plus deck text blobs for
+  `Modern`, `Standard`, `Pioneer`, `Legacy`, `Vintage`, and `Pauper`.
 - Daily metagame publishing runs at `02:45` UTC, which is `23:45` in
   `America/Sao_Paulo`, also as one job per format.
-- Each format job has its own concurrency key and only pushes when `data/`
-  changed.
+- Each format job has its own concurrency key, but only the final merge job
+  pushes when `data/` changed.
 
 ## Development
 

--- a/docs/publishing_workflows.md
+++ b/docs/publishing_workflows.md
@@ -2,21 +2,31 @@
 
 Scheduled publishing is split into two workflows:
 
-- `publish-hourly.yml` runs every hour at minute `15` and fans out into one job
-  per format for `Modern`, `Standard`, `Pioneer`, `Legacy`, `Vintage`, and
-  `Pauper`. Each job publishes current archetype/deck metadata plus referenced
-  deck-text blobs for just that format.
+- `publish-hourly.yml` runs every two hours at minute `15` and fans out into
+  one job per format for `Modern`, `Standard`, `Pioneer`, `Legacy`, `Vintage`,
+  and `Pauper`. Each job publishes current archetype/deck metadata plus
+  referenced deck-text blobs for just that format, uploads those format-scoped
+  results as artifacts, and a single downstream job merges and commits `data/`
+  once for the whole workflow.
 - `publish-daily.yml` runs at `02:45` UTC, which is `23:45` in
   `America/Sao_Paulo`, and also fans out into one job per format for the daily
   metagame aggregate.
 
 Each format job has its own concurrency group, so a new `Modern` run can block
-or wait on another `Modern` run without cancelling unrelated formats. Each
-workflow job:
+or wait on another `Modern` run without cancelling unrelated formats. For the
+hourly workflow, the per-format jobs no longer push directly, which avoids
+rebasing concurrent edits to shared files like `data/latest/latest.json`. Each
+format job:
 
 1. Runs the publisher CLI.
+2. Uploads only its format-scoped published files as an artifact.
+
+The hourly merge job then:
+
+1. Downloads all format artifacts into the checked-out tree.
 2. Prunes the checked-out tree with `python -m publisher.retention`.
-3. Commits and pushes `data/` only when the tree actually changed.
+3. Rebuilds `data/latest/latest.json` from the merged outputs.
+4. Commits and pushes `data/` only when the tree actually changed.
 
 Checked-tree retention is seven days for `data/hourly/` and `data/daily/`.
 `data/latest/` remains the stable consumer entrypoint, and deck-text blobs under

--- a/publisher/runner.py
+++ b/publisher/runner.py
@@ -68,6 +68,12 @@ def _parse_day(timestamp: str, override: str | None = None) -> str:
     return timestamp.split("T", 1)[0]
 
 
+def _command_label(command: str, formats: list[str] | None) -> str:
+    if not formats or len(formats) != 1:
+        return command
+    return f"{command}-{normalize_name(formats[0])}"
+
+
 def _parse_deck_date(date_str: str) -> datetime | None:
     for fmt in ("%Y-%m-%d", "%m/%d/%Y"):
         try:
@@ -664,9 +670,10 @@ def main(argv: list[str] | None = None) -> int:
     args = parser.parse_args(argv)
     generated_at = _parse_timestamp(args.timestamp)
     output_root = Path(args.output_root)
+    command_label = _command_label(args.command, getattr(args, "formats", None))
     recorder = RunRecorder(
         output_root=output_root,
-        command=args.command,
+        command=command_label,
         generated_at=generated_at,
         retention_days=args.retention_days,
         max_stale_hours=args.max_stale_hours,

--- a/tests/test_publisher_runner.py
+++ b/tests/test_publisher_runner.py
@@ -45,7 +45,7 @@ def test_scrape_archetypes_writes_run_manifest_and_posix_path(monkeypatch, tmp_p
     assert exit_code == 0
     latest_path = tmp_path / "latest" / "archetypes" / "modern.json"
     manifest_path = tmp_path / "latest" / "latest.json"
-    run_path = tmp_path / "latest" / "runs" / "scrape-archetypes.json"
+    run_path = tmp_path / "latest" / "runs" / "scrape-archetypes-modern.json"
     assert latest_path.exists()
     assert (tmp_path / "hourly" / "2026-03-23T12-00-00Z" / "archetypes" / "modern.json").exists()
     manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
@@ -92,7 +92,7 @@ def test_scrape_archetypes_uses_stale_fallback_when_latest_is_fresh(monkeypatch,
 
     assert second_exit == 0
     run_manifest = json.loads(
-        (tmp_path / "latest" / "runs" / "scrape-archetypes.json").read_text(encoding="utf-8")
+        (tmp_path / "latest" / "runs" / "scrape-archetypes-modern.json").read_text(encoding="utf-8")
     )
     assert run_manifest["results"][0]["status"] == "stale-fallback"
 
@@ -306,7 +306,7 @@ def test_scrape_deck_texts_reuses_existing_published_blob(monkeypatch, tmp_path)
     assert exit_code == 0
     assert sleeps == []
     run_manifest = json.loads(
-        (tmp_path / "latest" / "runs" / "scrape-deck-texts.json").read_text(encoding="utf-8")
+        (tmp_path / "latest" / "runs" / "scrape-deck-texts-modern.json").read_text(encoding="utf-8")
     )
     assert run_manifest["results"][-1]["status"] == "skipped"
     assert run_manifest["results"][-1]["message"] == "Reused existing published deck-text blob."


### PR DESCRIPTION
## Summary
- change the hourly publish schedule from every hour to every 2 hours
- shard single-format publisher run manifests to `data/latest/runs/<command>-<format>.json`
- stop per-format hourly jobs from pushing directly; upload format-scoped artifacts and commit once in a final merge job
- rebuild `data/latest/latest.json` once in the final hourly job to avoid concurrent JSON rewrites

## Testing
- `python3 -m pytest tests/test_publisher_runner.py tests/test_publisher_contracts.py tests/test_publisher_retention.py`
- `python3 -m ruff check .`
- `python3 -m black --check .`
