### PR TITLE
Retry empty archetype deck scrapes

### DIFF
--- a/navigators/mtggoldfish.py
+++ b/navigators/mtggoldfish.py
@@ -28,6 +28,8 @@ from utils.constants import (
 from utils.deck_text_cache import get_deck_cache
 from utils.json_io import fast_load
 
+EMPTY_ARCHETYPE_DECK_RETRY_DELAYS_SECONDS = (2, 5, 10)
+
 
 def _load_cached_archetypes(mtg_format: str, max_age: int = METAGAME_CACHE_TTL_SECONDS):
     if not ARCHETYPE_LIST_CACHE_FILE.exists():
@@ -141,6 +143,38 @@ def _save_cached_archetype_decks(archetype: str, items: list[dict]):
         json.dump(data, fh, indent=2)
 
 
+def _parse_archetype_decks(page_text: str, archetype: str) -> list[dict]:
+    soup = bs4.BeautifulSoup(page_text, "lxml")
+    table = soup.select_one("table.table-striped")
+    if not table:
+        logger.warning(f"Deck table missing for archetype {archetype}")
+        return []
+
+    trs: list[bs4.Tag] = table.find_all("tr")[1:]
+    decks: list[dict] = []
+    for tr in trs:
+        tds: list[bs4.Tag] = tr.find_all("td")
+        if len(tds) <= GOLDFISH_DECK_TABLE_COL_RESULT:
+            logger.warning(f"Deck row missing expected columns for archetype {archetype}")
+            continue
+        deck_link = tds[GOLDFISH_DECK_TABLE_COL_NUMBER].select_one("a")
+        if deck_link is None:
+            logger.warning(f"Deck row missing deck link for archetype {archetype}")
+            continue
+        decks.append(
+            {
+                "date": tds[GOLDFISH_DECK_TABLE_COL_DATE].text.strip(),
+                "number": deck_link.attrs.get("href").replace("/deck/", ""),
+                "player": tds[GOLDFISH_DECK_TABLE_COL_PLAYER].text.strip(),
+                "event": tds[GOLDFISH_DECK_TABLE_COL_EVENT].text.strip(),
+                "result": tds[GOLDFISH_DECK_TABLE_COL_RESULT].text.strip(),
+                "name": archetype,
+                "source": "mtggoldfish",
+            }
+        )
+    return decks
+
+
 def get_archetype_decks(archetype: str):
     # Check cache first
     cached = _load_cached_archetype_decks(archetype)
@@ -149,41 +183,36 @@ def get_archetype_decks(archetype: str):
         return cached
 
     logger.debug(f"Fetching decks for archetype {archetype} from MTGGoldfish")
-    try:
-        page = requests.get(
-            f"https://www.mtggoldfish.com/archetype/{archetype}/decks",
-            impersonate="chrome",
-            timeout=MTGGOLDFISH_REQUEST_TIMEOUT_SECONDS,
-        )
-        page.raise_for_status()
-    except Exception as exc:
-        logger.error(f"Failed to fetch decks for archetype {archetype}: {exc}")
+    retry_delays = (0, *EMPTY_ARCHETYPE_DECK_RETRY_DELAYS_SECONDS)
+    decks: list[dict] = []
+    for attempt, delay_seconds in enumerate(retry_delays, start=1):
+        if delay_seconds:
+            logger.warning(
+                "No deck rows returned for archetype {}. Retrying in {} seconds (attempt {}/{})",
+                archetype,
+                delay_seconds,
+                attempt,
+                len(retry_delays),
+            )
+            time.sleep(delay_seconds)
+        try:
+            page = requests.get(
+                f"https://www.mtggoldfish.com/archetype/{archetype}/decks",
+                impersonate="chrome",
+                timeout=MTGGOLDFISH_REQUEST_TIMEOUT_SECONDS,
+            )
+            page.raise_for_status()
+        except Exception as exc:
+            logger.error(f"Failed to fetch decks for archetype {archetype}: {exc}")
+            return []
+
+        decks = _parse_archetype_decks(page.text, archetype)
+        if decks:
+            break
+    else:
+        logger.warning(f"Deck scrape returned no rows for archetype {archetype} after retries")
         return []
 
-    soup = bs4.BeautifulSoup(page.text, "lxml")
-    table = soup.select_one("table.table-striped")
-    if not table:
-        logger.warning(f"Deck table missing for archetype {archetype}")
-        return []
-    trs: list[bs4.Tag] = table.find_all("tr")
-    trs = trs[1:]
-    decks = []
-    for tr in trs:
-        tds: list[bs4.Tag] = tr.find_all("td")
-        decks.append(
-            {
-                "date": tds[GOLDFISH_DECK_TABLE_COL_DATE].text.strip(),
-                "number": tds[GOLDFISH_DECK_TABLE_COL_NUMBER]
-                .select_one("a")
-                .attrs.get("href")
-                .replace("/deck/", ""),
-                "player": tds[GOLDFISH_DECK_TABLE_COL_PLAYER].text.strip(),
-                "event": tds[GOLDFISH_DECK_TABLE_COL_EVENT].text.strip(),
-                "result": tds[GOLDFISH_DECK_TABLE_COL_RESULT].text.strip(),
-                "name": archetype,
-                "source": "mtggoldfish",
-            }
-        )
     # Save to cache
     _save_cached_archetype_decks(archetype, decks)
     return decks

--- a/tests/test_mtggoldfish.py
+++ b/tests/test_mtggoldfish.py
@@ -131,6 +131,13 @@ def temp_archetype_list_file(temp_cache_dir):
 
 
 @pytest.fixture
+def temp_archetype_decks_file(temp_cache_dir):
+    """Create a temporary archetype deck cache file."""
+    cache_file = temp_cache_dir / "archetype_decks.json"
+    return cache_file
+
+
+@pytest.fixture
 def temp_curr_deck_file(temp_cache_dir):
     """Create a temporary current deck file."""
     curr_deck_file = temp_cache_dir / "curr_deck.txt"
@@ -336,14 +343,15 @@ class TestGetArchetypeDecks:
     """Test get_archetype_decks function."""
 
     @patch("navigators.mtggoldfish.requests.get")
-    def test_get_archetype_decks_success(self, mock_get):
+    def test_get_archetype_decks_success(self, mock_get, temp_archetype_decks_file):
         """Test successfully fetching archetype decks."""
         mock_response = Mock()
         mock_response.text = SAMPLE_ARCHETYPE_DECKS_HTML
         mock_response.raise_for_status = Mock()
         mock_get.return_value = mock_response
 
-        result = get_archetype_decks("modern-rakdos-midrange")
+        with patch("navigators.mtggoldfish.ARCHETYPE_DECKS_CACHE_FILE", temp_archetype_decks_file):
+            result = get_archetype_decks("modern-rakdos-midrange")
 
         assert len(result) == 2
         assert result[0]["date"] == "Jan 15"
@@ -357,27 +365,79 @@ class TestGetArchetypeDecks:
         assert result[1]["player"] == "PlayerTwo"
 
     @patch("navigators.mtggoldfish.requests.get")
-    def test_get_archetype_decks_request_failure(self, mock_get):
+    def test_get_archetype_decks_request_failure(self, mock_get, temp_archetype_decks_file):
         """Test handling request failure returns cached data."""
-        mock_get.side_effect = Exception("Network error")
+        with patch("navigators.mtggoldfish.ARCHETYPE_DECKS_CACHE_FILE", temp_archetype_decks_file):
+            success_response = Mock()
+            success_response.text = SAMPLE_ARCHETYPE_DECKS_HTML
+            success_response.raise_for_status = Mock()
+            mock_get.return_value = success_response
+            get_archetype_decks("modern-rakdos-midrange")
+            mock_get.side_effect = Exception("Network error")
 
-        # Should return cached data from previous successful test
-        result = get_archetype_decks("modern-rakdos-midrange")
-        assert len(result) == 2  # Returns cached data as fallback
-        assert result[0]["number"] == "123456"
+            result = get_archetype_decks("modern-rakdos-midrange")
+            assert len(result) == 2
+            assert result[0]["number"] == "123456"
 
     @patch("navigators.mtggoldfish.requests.get")
-    def test_get_archetype_decks_missing_table(self, mock_get):
+    def test_get_archetype_decks_missing_table(self, mock_get, temp_archetype_decks_file):
         """Test handling missing deck table returns cached data."""
-        mock_response = Mock()
-        mock_response.text = "<html><body>No table here</body></html>"
-        mock_response.raise_for_status = Mock()
-        mock_get.return_value = mock_response
+        with patch("navigators.mtggoldfish.ARCHETYPE_DECKS_CACHE_FILE", temp_archetype_decks_file):
+            success_response = Mock()
+            success_response.text = SAMPLE_ARCHETYPE_DECKS_HTML
+            success_response.raise_for_status = Mock()
+            mock_get.return_value = success_response
+            get_archetype_decks("modern-rakdos-midrange")
 
-        # Should return cached data from previous successful test
-        result = get_archetype_decks("modern-rakdos-midrange")
-        assert len(result) == 2  # Returns cached data as fallback
-        assert result[0]["number"] == "123456"
+            mock_response = Mock()
+            mock_response.text = "<html><body>No table here</body></html>"
+            mock_response.raise_for_status = Mock()
+            mock_get.return_value = mock_response
+
+            result = get_archetype_decks("modern-rakdos-midrange")
+            assert len(result) == 2
+            assert result[0]["number"] == "123456"
+
+    @patch("navigators.mtggoldfish.time.sleep")
+    @patch("navigators.mtggoldfish.requests.get")
+    def test_get_archetype_decks_retries_empty_rows_then_succeeds(
+        self, mock_get, mock_sleep, temp_archetype_decks_file
+    ):
+        """Test empty deck pages are retried with backoff before succeeding."""
+        empty_response = Mock()
+        empty_response.text = "<html><body><table class='table-striped'><tr><th>Header</th></tr></table></body></html>"
+        empty_response.raise_for_status = Mock()
+
+        success_response = Mock()
+        success_response.text = SAMPLE_ARCHETYPE_DECKS_HTML
+        success_response.raise_for_status = Mock()
+
+        mock_get.side_effect = [empty_response, empty_response, empty_response, success_response]
+
+        with patch("navigators.mtggoldfish.ARCHETYPE_DECKS_CACHE_FILE", temp_archetype_decks_file):
+            result = get_archetype_decks("modern-rakdos-midrange")
+
+        assert len(result) == 2
+        assert [call.args[0] for call in mock_sleep.call_args_list] == [2, 5, 10]
+        assert mock_get.call_count == 4
+
+    @patch("navigators.mtggoldfish.time.sleep")
+    @patch("navigators.mtggoldfish.requests.get")
+    def test_get_archetype_decks_returns_empty_after_retry_exhaustion(
+        self, mock_get, mock_sleep, temp_archetype_decks_file
+    ):
+        """Test empty deck pages fail only after the final backoff retry."""
+        empty_response = Mock()
+        empty_response.text = "<html><body>No table here</body></html>"
+        empty_response.raise_for_status = Mock()
+        mock_get.return_value = empty_response
+
+        with patch("navigators.mtggoldfish.ARCHETYPE_DECKS_CACHE_FILE", temp_archetype_decks_file):
+            result = get_archetype_decks("modern-rakdos-midrange")
+
+        assert result == []
+        assert [call.args[0] for call in mock_sleep.call_args_list] == [2, 5, 10]
+        assert mock_get.call_count == 4
 
 
 class TestGetDailyDecks:


### PR DESCRIPTION
## Summary
- retry archetype deck scrapes when the source page returns no deck rows
- back off for 2, 5, and 10 seconds before giving up
- add tests covering eventual success after retries and final failure after retry exhaustion

## Testing
- `python3 -m pytest tests/test_mtggoldfish.py`
- `python3 -m ruff check navigators/mtggoldfish.py tests/test_mtggoldfish.py`
- `python3 -m black --check navigators/mtggoldfish.py tests/test_mtggoldfish.py`
