### PR TITLE
Avoid publish-daily merge conflicts

### DIFF
--- a/.github/workflows/publish-daily.yml
+++ b/.github/workflows/publish-daily.yml
@@ -57,11 +57,175 @@ jobs:
           echo "exit_code=$exit_code" >> "$GITHUB_OUTPUT"
           exit 0
 
+      - name: Package format artifact
+        if: always()
+        env:
+          MATRIX_FORMAT: ${{ matrix.format }}
+        run: |
+          python - <<'PY'
+          import os
+          import shutil
+          from pathlib import Path
+
+          from publisher.layout import normalize_name
+
+          data_root = Path(os.environ["PUBLISH_OUTPUT_ROOT"])
+          artifact_root = Path("artifact")
+          normalized_format = normalize_name(os.environ["MATRIX_FORMAT"])
+          artifact_root.mkdir(parents=True, exist_ok=True)
+
+          def copy_path(path: Path) -> None:
+              if not path.exists():
+                  return
+              if path.is_dir():
+                  for child in path.rglob("*"):
+                      if child.is_file():
+                          destination = artifact_root / child.relative_to(data_root)
+                          destination.parent.mkdir(parents=True, exist_ok=True)
+                          shutil.copy2(child, destination)
+                  return
+              destination = artifact_root / path.relative_to(data_root)
+              destination.parent.mkdir(parents=True, exist_ok=True)
+              shutil.copy2(path, destination)
+
+          copy_path(data_root / "latest" / "metagame" / f"{normalized_format}.json")
+          copy_path(data_root / "latest" / "runs" / f"scrape-metagame-{normalized_format}.json")
+
+          daily_root = data_root / "daily"
+          if daily_root.exists():
+              for snapshot_dir in daily_root.iterdir():
+                  if not snapshot_dir.is_dir():
+                      continue
+                  copy_path(snapshot_dir / "metagame" / f"{normalized_format}.json")
+
+          hourly_root = data_root / "hourly"
+          if hourly_root.exists():
+              for snapshot_dir in hourly_root.iterdir():
+                  if not snapshot_dir.is_dir():
+                      continue
+                  copy_path(snapshot_dir / "runs" / f"scrape-metagame-{normalized_format}.json")
+
+          metadata_path = artifact_root / ".artifact-format"
+          metadata_path.write_text(f"{normalized_format}\n", encoding="utf-8")
+          PY
+
+      - name: Upload format artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: publish-daily-${{ matrix.format }}
+          path: artifact
+          if-no-files-found: error
+
+      - name: Fail if freshness guarantees were violated
+        if: steps.publish.outputs.exit_code != '0'
+        run: |
+          echo "Publisher exited with code ${{ steps.publish.outputs.exit_code }}."
+          exit 1
+
+  commit-daily:
+    needs: publish-daily
+    if: always()
+    runs-on: ubuntu-latest
+    env:
+      PUBLISH_OUTPUT_ROOT: data
+      PUBLISH_RETENTION_DAYS: "7"
+      TZ: America/Sao_Paulo
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements-dev.txt
+
+      - name: Download format artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: publish-daily-*
+          merge-multiple: true
+          path: .
+
       - name: Prune retained working tree
         run: |
           python -m publisher.retention \
             --output-root "$PUBLISH_OUTPUT_ROOT" \
             --retention-days "$PUBLISH_RETENTION_DAYS"
+
+      - name: Rebuild latest manifest
+        run: |
+          python - <<'PY'
+          from datetime import UTC, datetime
+          import json
+          import os
+          from pathlib import Path
+
+          from publisher.contracts import build_latest_manifest
+          from publisher.layout import normalize_name, write_json
+
+          output_root = Path(os.environ["PUBLISH_OUTPUT_ROOT"])
+          retention_days = int(os.environ["PUBLISH_RETENTION_DAYS"])
+          generated_at = datetime.now(UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+          manifest = build_latest_manifest(generated_at=generated_at, retention_days=retention_days)
+
+          def load_payload(path: Path) -> dict:
+              return json.loads(path.read_text(encoding="utf-8"))
+
+          def relative_path(path: Path) -> str:
+              return path.relative_to(output_root).as_posix()
+
+          def append_entry(category: str, path: Path, format_value: str | None = None, **extra: str) -> None:
+              payload = load_payload(path)
+              manifest["latest"][category].append(
+                  {
+                      "format": format_value or payload.get("format") or path.stem,
+                      "path": relative_path(path),
+                      "updated_at": payload.get("generated_at", generated_at),
+                      **extra,
+                  }
+              )
+
+          for path in sorted((output_root / "latest" / "archetypes").glob("*.json")):
+              append_entry("archetype_lists", path)
+
+          for path in sorted((output_root / "latest" / "decks").rglob("*.json")):
+              payload = load_payload(path)
+              archetype = payload.get("archetype", {})
+              append_entry(
+                  "archetype_decks",
+                  path,
+                  archetype=normalize_name(archetype.get("name", path.stem)),
+              )
+
+          for path in sorted((output_root / "latest" / "metagame").glob("*.json")):
+              append_entry("metagame_daily", path)
+
+          for path in sorted((output_root / "archive" / "deck-texts").rglob("*.json")):
+              payload = load_payload(path)
+              append_entry(
+                  "deck_text_blobs",
+                  path,
+                  deck_id=str(payload.get("deck_id", path.stem)),
+              )
+
+          for path in sorted((output_root / "latest" / "runs").glob("*.json")):
+              payload = load_payload(path)
+              append_entry(
+                  "runs",
+                  path,
+                  format_value=payload.get("command", path.stem),
+              )
+
+          write_json(output_root / "latest" / "latest.json", manifest)
+          PY
 
       - name: Commit changed snapshots
         run: |
@@ -73,12 +237,5 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add "$PUBLISH_OUTPUT_ROOT"
-          git commit -m "Publish daily metagame snapshots for ${{ matrix.format }}"
-          git pull --rebase origin "${GITHUB_REF_NAME}"
+          git commit -m "Publish daily metagame snapshots"
           git push origin HEAD:"${GITHUB_REF_NAME}"
-
-      - name: Fail if freshness guarantees were violated
-        if: steps.publish.outputs.exit_code != '0'
-        run: |
-          echo "Publisher exited with code ${{ steps.publish.outputs.exit_code }}."
-          exit 1


### PR DESCRIPTION
## Summary
- switch the daily publish workflow to upload per-format artifacts instead of committing from each matrix job
- add a final merge job that downloads artifacts, prunes retention, rebuilds the shared latest manifest, and performs the only push
- keep per-format freshness failures visible while removing cross-job git conflicts

## Testing
- python3 -m ruff check .
- python3 -m black --check .
- python3 - <<'PY'
import yaml
from pathlib import Path
with Path('.github/workflows/publish-daily.yml').open('r', encoding='utf-8') as fh:
    yaml.safe_load(fh)
print('yaml ok')
PY