### PR TITLE
Fix publish artifact download destination

### DIFF
--- a/.github/workflows/publish-daily.yml
+++ b/.github/workflows/publish-daily.yml
@@ -152,7 +152,7 @@ jobs:
         with:
           pattern: publish-daily-*
           merge-multiple: true
-          path: .
+          path: ${{ env.PUBLISH_OUTPUT_ROOT }}
 
       - name: Prune retained working tree
         run: |

--- a/.github/workflows/publish-hourly.yml
+++ b/.github/workflows/publish-hourly.yml
@@ -150,7 +150,7 @@ jobs:
         with:
           pattern: publish-hourly-*
           merge-multiple: true
-          path: .
+          path: ${{ env.PUBLISH_OUTPUT_ROOT }}
 
       - name: Prune retained working tree
         run: |


### PR DESCRIPTION
## Problem
The publish workflows upload per-format artifacts under paths relative to `data/` (for example `latest/...`), but commit jobs were downloading artifacts into repository root (`.`).

As a result, downloaded files landed under `./latest` instead of `./data/latest`, so retention and manifest rebuild mostly operated on stale checkout data and published commits could miss fresh scrape outputs.

## Fix
- download hourly artifacts into `${{ env.PUBLISH_OUTPUT_ROOT }}`
- download daily artifacts into `${{ env.PUBLISH_OUTPUT_ROOT }}`

This makes extracted artifact paths resolve to `data/latest`, `data/hourly`, `data/daily`, and `data/archive` before prune/rebuild/commit steps.

## Validation
- `python3 -m ruff check .`
- `python3 -m black --check .`
- YAML parse check for both publish workflows
