### PR TITLE
Force LF line endings for shell scripts

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.sh text eol=lf


### PR DESCRIPTION
## Summary
- add `.gitattributes` entry `*.sh text eol=lf`
- prevents CRLF checkout for shell scripts so WSL can execute shebangs correctly (`/usr/bin/env: 'bash\r'`)

## Validation
- `python3 -m ruff check .`
- `python3 -m black --check .`
