### PR TITLE
Fix MTGGoldfish deck scrape via /deck/visual/ fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,13 @@
 
 Headless MTGO and MTGGoldfish scraping surface for scheduled publishing.
 
+This repository was carved out of [Pedrogush/MTGO_Tools](https://github.com/Pedrogush/MTGO_Tools)
+— the original full desktop application — and reduced to its scraper and
+publisher path. Fixes that affect the live scrapers (e.g. MTGGoldfish
+Cloudflare blocks, MTGO.com payload format changes) are typically discovered
+in `MTGO_Tools` first; check that repo's `navigators/` module for the
+authoritative implementation when this one stops collecting data.
+
 ![Version](https://img.shields.io/badge/version-0.2-blue)
 ![Python](https://img.shields.io/badge/python-3.11+-green)
 ![Platform](https://img.shields.io/badge/platform-headless-lightgrey)

--- a/navigators/mtggoldfish.py
+++ b/navigators/mtggoldfish.py
@@ -1,8 +1,6 @@
 import json
-import re
 import time
 from datetime import datetime, timedelta
-from urllib.parse import unquote
 
 import bs4
 from curl_cffi import requests
@@ -371,18 +369,17 @@ def fetch_deck_text(deck_num: str, source_filter: str | None = None) -> str:
         )
         raise ValueError(f"Deck {deck_num} not available from MTGO source")
 
-    # Download from MTGGoldfish
+    # The /deck/{id} endpoint sits behind Cloudflare's managed challenge, so we
+    # fetch from /deck/visual/{id} which is served unprotected.
     logger.info(f"Downloading deck {deck_num} from MTGGoldfish")
-    page = requests.get(f"https://www.mtggoldfish.com/deck/{deck_num}", impersonate="chrome")
-    match = re.search(r'initializeDeckComponents\([^,]+,\s*[^,]+,\s*"([^"]+)"', page.text)
-    if not match:
-        logger.error(f"Could not find deck data for deck {deck_num}")
-        raise ValueError(f"Could not parse deck data for deck {deck_num}")
+    from navigators.mtggoldfish_visual import fetch_deck_text_from_visual_page
 
-    encoded_deck = match.group(1)
-    deck_text = unquote(encoded_deck)
+    try:
+        deck_text = fetch_deck_text_from_visual_page(deck_num)
+    except Exception as exc:
+        logger.error(f"Visual-page fetch failed for deck {deck_num}: {exc}")
+        raise ValueError(f"Could not parse deck data for deck {deck_num}") from exc
 
-    # Store in cache with mtggoldfish source
     cache.set(deck_num, deck_text, source="mtggoldfish")
 
     return deck_text

--- a/navigators/mtggoldfish_visual.py
+++ b/navigators/mtggoldfish_visual.py
@@ -1,0 +1,63 @@
+"""Fallback deck fetcher that scrapes the MTGGoldfish ``/deck/visual/`` page.
+
+The standard ``/deck/{id}`` endpoint is now behind Cloudflare's *managed*
+challenge, which rejects every headless browser and every plain-HTTP client we
+could try. The public ``/deck/visual/{id}`` view, however, is served without the
+challenge and embeds one ``<img class="deck-visual-pile-card" alt="...">`` per
+card copy inside ``.deck-visual-playmat-maindeck`` and
+``.deck-visual-playmat-sideboard`` containers. Counting those by alt text
+reconstructs the same plain-text deck list the primary scraper produces.
+"""
+
+from __future__ import annotations
+
+from collections import OrderedDict
+
+import bs4
+from curl_cffi import requests
+from loguru import logger
+
+from utils.constants import MTGGOLDFISH_REQUEST_TIMEOUT_SECONDS
+
+_MAIN_SELECTOR = ".deck-visual-playmat-maindeck"
+_SIDE_SELECTOR = ".deck-visual-playmat-sideboard"
+_CARD_IMG_SELECTOR = "img.deck-visual-pile-card"
+
+
+def _count_cards(section: bs4.Tag | None) -> OrderedDict[str, int]:
+    counts: OrderedDict[str, int] = OrderedDict()
+    if section is None:
+        return counts
+    for img in section.select(_CARD_IMG_SELECTOR):
+        name = (img.get("alt") or "").strip()
+        if not name:
+            continue
+        counts[name] = counts.get(name, 0) + 1
+    return counts
+
+
+def _format_deck_text(mainboard: OrderedDict[str, int], sideboard: OrderedDict[str, int]) -> str:
+    main_text = "\n".join(f"{c} {n}" for n, c in mainboard.items())
+    if not sideboard:
+        return main_text
+    side_text = "\n".join(f"{c} {n}" for n, c in sideboard.items())
+    return f"{main_text}\n\n{side_text}"
+
+
+def parse_visual_page(html: str) -> str:
+    """Extract a plain-text decklist from rendered ``/deck/visual/`` HTML."""
+    soup = bs4.BeautifulSoup(html, "lxml")
+    mainboard = _count_cards(soup.select_one(_MAIN_SELECTOR))
+    sideboard = _count_cards(soup.select_one(_SIDE_SELECTOR))
+    if not mainboard and not sideboard:
+        raise ValueError("Visual deck page contained no card piles")
+    return _format_deck_text(mainboard, sideboard)
+
+
+def fetch_deck_text_from_visual_page(deck_num: str) -> str:
+    """Fallback fetcher: pull the deck text from the unprotected visual view."""
+    url = f"https://www.mtggoldfish.com/deck/visual/{deck_num}"
+    logger.info(f"Fetching deck {deck_num} from MTGGoldfish visual")
+    page = requests.get(url, impersonate="chrome", timeout=MTGGOLDFISH_REQUEST_TIMEOUT_SECONDS)
+    page.raise_for_status()
+    return parse_visual_page(page.text)


### PR DESCRIPTION
## Summary

- The MTGGoldfish `/deck/{id}` endpoint is now behind Cloudflare's managed challenge, returning HTTP 403 with a challenge page. The existing `initializeDeckComponents` regex can't parse it, so every hourly `publish-data` run was producing 540+ `Could not parse deck data` hard-failures per format.
- Port the visual-page approach already deployed in `Pedrogush/MTGO_Tools` (commits `1e421a2` + `fb3cfcd`): scrape `/deck/visual/{id}` (which CF doesn't gate) and rebuild the decklist by counting `img.deck-visual-pile-card` elements in the maindeck and sideboard playmat sections. New `navigators/mtggoldfish_visual.py` module; `fetch_deck_text` in `navigators/mtggoldfish.py` now delegates to it. The dead `/deck/{id}` + regex path is removed.
- Add a back-reference to `Pedrogush/MTGO_Tools` near the top of `README.md` so future live-scraper regressions know where the upstream fix usually lands first.
- MTGO.com (`scrape-mtgo-decklists`) is unaffected — recent runs show `success=1, cached=17` and a live test parsed 31 events with 32 decklists each.

## Test plan

- [x] `python -m pytest tests/` — 85 passed
- [x] `ruff check navigators/mtggoldfish.py navigators/mtggoldfish_visual.py`
- [x] `black --check navigators/mtggoldfish.py navigators/mtggoldfish_visual.py`
- [x] Live fetch: `fetch_deck_text("7751759", source_filter="mtggoldfish")` returns the full 60-card mainboard + sideboard
- [ ] Watch the next scheduled `publish-data.yml` run and confirm `scrape-deck-texts` hard-failures drop to 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)