### PR TITLE
Fix empty sideboards in published radars

### DIFF
--- a/services/radar_service.py
+++ b/services/radar_service.py
@@ -221,6 +221,8 @@ class RadarService:
         for raw_line in deck_text.splitlines():
             line = raw_line.strip()
             if not line:
+                if current_zone is mainboard and mainboard:
+                    current_zone = sideboard
                 continue
 
             if line.lower() in _SIDEBOARD_MARKERS:

--- a/tests/test_radar_service.py
+++ b/tests/test_radar_service.py
@@ -133,6 +133,52 @@ def test_calculate_radar_from_deck_texts_parses_sideboard_and_duplicate_lines():
     assert pyroblast.copy_distribution == {2: 1, 1: 1}
 
 
+def test_parse_deck_text_recognizes_lowercase_sideboard_marker():
+    service = RadarService()
+
+    parsed = service._parse_deck_text(
+        "4 Lightning Bolt\n2 Island\nsideboard\n3 Pyroblast\n1 Red Elemental Blast\n"
+    )
+
+    assert dict(parsed["mainboard_cards"]) == {"Lightning Bolt": 4, "Island": 2}
+    assert dict(parsed["sideboard_cards"]) == {"Pyroblast": 3, "Red Elemental Blast": 1}
+
+
+def test_parse_deck_text_recognizes_blank_line_separator():
+    service = RadarService()
+
+    parsed = service._parse_deck_text(
+        "4 Lightning Bolt\n2 Island\n\n3 Pyroblast\n1 Red Elemental Blast\n"
+    )
+
+    assert dict(parsed["mainboard_cards"]) == {"Lightning Bolt": 4, "Island": 2}
+    assert dict(parsed["sideboard_cards"]) == {"Pyroblast": 3, "Red Elemental Blast": 1}
+
+
+def test_calculate_radar_from_deck_texts_handles_blank_line_sideboard_separator():
+    service = RadarService()
+
+    radar = service.calculate_radar_from_deck_texts(
+        archetype_name="Painter",
+        format_name="legacy",
+        deck_texts=[
+            "4 Goblin Welder\n1 Lotus Petal\n1 Lotus Petal\n\n2 Pyroblast\n",
+            "4 Goblin Welder\n2 Grindstone\n\n1 Pyroblast\n1 Red Elemental Blast\n",
+        ],
+    )
+
+    welder = next(item for item in radar.mainboard_cards if item.card_name == "Goblin Welder")
+    petal = next(item for item in radar.mainboard_cards if item.card_name == "Lotus Petal")
+    pyroblast = next(item for item in radar.sideboard_cards if item.card_name == "Pyroblast")
+
+    assert radar.total_decks_analyzed == 2
+    assert pyroblast.appearances == 2
+    assert pyroblast.total_copies == 3
+    assert welder.expected_copies == 4.0
+    assert petal.total_copies == 2
+    assert all(card.card_name != "Pyroblast" for card in radar.mainboard_cards)
+
+
 def test_export_radar_as_decklist():
     service = RadarService()
     radar = RadarData(


### PR DESCRIPTION
## Summary

The 2026-05-03 client bundle ships 225 archetype radars with empty `sideboard_cards` despite populated `mainboard_cards` — a regression from the older bundles. Root cause: a recent MTGGoldfish scrape change (`/deck/visual/` fallback) returns deck texts that delimit the sideboard with a blank line instead of the literal `sideboard` marker, but `RadarService._parse_deck_text` skips blank lines unconditionally and never flips into sideboard mode, so sideboard cards get aggregated into the mainboard or lost.

This change updates `_parse_deck_text` so the first blank line *after* mainboard content has been collected switches the parser into sideboard mode, matching the deck-text consumer parser in MTGO_Tools (`DeckParserMixin._iter_entries`). The existing `sideboard` / `sb:` / `sb` lowercase markers continue to work.

## Test plan

- [x] `pytest tests/test_radar_service.py` — 8 passed (3 new tests cover lowercase marker, blank-line separator, and end-to-end aggregation through the blank-line form).
- [x] `pytest tests/` — 88 passed, no regressions.
- [x] Replayed a real published 2026-05-03 deck text (`archive/deck-texts/modern/7764241.json`) through the patched parser and confirmed it now yields 22 mainboard cards and 9 sideboard cards (previously 0 sideboard).
- [ ] Re-run the `publish-data` workflow once merged and spot-check `latest/radars/legacy/affinity-stompy.json` to confirm `sideboard_cards` is populated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)